### PR TITLE
Add stable vertical gallery navigation

### DIFF
--- a/src/components/PreviewGalleryDialog.tsx
+++ b/src/components/PreviewGalleryDialog.tsx
@@ -1,6 +1,6 @@
 import { Dialog } from "@base-ui/react/dialog"
 import { useSound } from "@web-kits/audio/react"
-import { ChevronLeft, ChevronRight, X } from "lucide-react"
+import { ChevronDown, ChevronLeft, ChevronRight, ChevronUp, X } from "lucide-react"
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from "react"
 
 import type { PortfolioCard } from "../data/portfolio"
@@ -354,6 +354,29 @@ export function PreviewGalleryDialog({
               </div>
             </article>
 
+            <div className="preview-gallery-rail" role="group" aria-label="Preview navigation">
+              <button
+                type="button"
+                className="preview-gallery-nav preview-gallery-nav-prev"
+                aria-label="Previous preview"
+                aria-keyshortcuts="ArrowUp ArrowLeft"
+                onClick={() => moveBy(-1)}
+                disabled={cards.length <= 1}
+              >
+                <ChevronUp aria-hidden="true" strokeWidth={2} className="preview-gallery-nav-icon" />
+              </button>
+
+              <button
+                type="button"
+                className="preview-gallery-nav preview-gallery-nav-next"
+                aria-label="Next preview"
+                aria-keyshortcuts="ArrowDown ArrowRight"
+                onClick={() => moveBy(1)}
+                disabled={cards.length <= 1}
+              >
+                <ChevronDown aria-hidden="true" strokeWidth={2} className="preview-gallery-nav-icon" />
+              </button>
+            </div>
           </Dialog.Popup>
         </div>
       </Dialog.Portal>

--- a/src/index.css
+++ b/src/index.css
@@ -2088,6 +2088,7 @@ img {
 }
 
 .preview-gallery-shell {
+  --preview-gallery-fixed-top: max(8vh, env(safe-area-inset-top));
   position: fixed;
   inset: 0;
   z-index: 70;
@@ -2098,7 +2099,7 @@ img {
   overflow-y: auto;
   overscroll-behavior: contain;
   padding:
-    max(clamp(1rem, 5vh, 3rem), env(safe-area-inset-top))
+    var(--preview-gallery-fixed-top)
     max(clamp(1rem, 3vw, 2.5rem), env(safe-area-inset-right))
     max(1rem, env(safe-area-inset-bottom))
     max(clamp(1rem, 3vw, 2.5rem), env(safe-area-inset-left));
@@ -2110,10 +2111,8 @@ img {
   width: min(544px, 100%);
   max-height: calc(100dvh - max(2rem, env(safe-area-inset-top) + env(safe-area-inset-bottom)));
   outline: none;
-  overflow-x: hidden;
-  overflow-y: auto;
   overscroll-behavior: contain;
-  border-radius: clamp(1.85rem, 4vw, 3.5rem);
+  border-radius: clamp(1.85rem, 4vw, 3.5rem) clamp(1.85rem, 4vw, 3.5rem) 28px 28px;
   cursor: default;
   opacity: 1;
   transform: translateY(0) scale(1);
@@ -2137,8 +2136,11 @@ img {
   --preview-gallery-card-padding: clamp(1.3rem, 2.4vw, 2rem);
   --preview-gallery-media-radius: 24px;
   --preview-gallery-card-radius: calc(var(--preview-gallery-media-radius) + var(--preview-gallery-card-padding));
-  overflow: visible;
-  border-radius: var(--preview-gallery-card-radius);
+  max-height: calc(100dvh - var(--preview-gallery-fixed-top) - max(1rem, env(safe-area-inset-bottom)));
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  border-radius: var(--preview-gallery-card-radius) var(--preview-gallery-card-radius) 28px 28px;
   border: 1px solid rgb(0 0 0 / 0.08);
   background: #ffffff;
   padding: var(--preview-gallery-card-padding);
@@ -2218,6 +2220,17 @@ img {
   display: inline-flex;
   align-items: center;
   gap: 0.45rem;
+}
+
+.preview-gallery-rail {
+  position: absolute;
+  z-index: 1;
+  top: 128px;
+  left: calc(100% + 16px);
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  transform: translateY(-50%);
 }
 
 .preview-gallery-heading {
@@ -2747,8 +2760,21 @@ img {
 }
 
 @media (max-width: 699.98px), (hover: none), (pointer: coarse) {
+  .preview-gallery-shell {
+    --preview-gallery-fixed-top: max(clamp(1rem, 5vh, 3rem), env(safe-area-inset-top));
+  }
+
+  .preview-gallery-rail {
+    display: none;
+  }
+
   .preview-gallery-toolbar {
     display: flex;
+  }
+
+  .preview-gallery-toolbar .preview-gallery-nav-prev .preview-gallery-nav-icon,
+  .preview-gallery-toolbar .preview-gallery-nav-next .preview-gallery-nav-icon {
+    transform: rotate(90deg);
   }
 
   .mosaic-row-card-title {

--- a/tests/e2e/portfolio-polish.spec.ts
+++ b/tests/e2e/portfolio-polish.spec.ts
@@ -74,6 +74,48 @@ test("returns focus to the originating project after closing the gallery", async
   await expect(trigger).toBeFocused()
 })
 
+test("keeps desktop gallery navigation fixed near the modal top", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 1000 })
+  await page.emulateMedia({ reducedMotion: "reduce" })
+  await page.goto("/")
+  await page.getByRole("button", { name: /Open Matcha - Multiwallet flow/ }).click()
+
+  const dialog = page.getByRole("dialog")
+  const card = dialog.locator(".preview-gallery-card")
+  const rail = dialog.locator(".preview-gallery-rail")
+  const previous = rail.getByRole("button", { name: "Previous preview" })
+  const next = rail.getByRole("button", { name: "Next preview" })
+
+  await expect(rail).toBeVisible()
+  await expect(previous).toHaveAttribute("aria-keyshortcuts", "ArrowUp ArrowLeft")
+  await expect(next).toHaveAttribute("aria-keyshortcuts", "ArrowDown ArrowRight")
+  await expect(card).toHaveCSS("border-bottom-left-radius", "28px")
+  await expect(card).toHaveCSS("border-bottom-right-radius", "28px")
+
+  const initialDialogBox = await dialog.boundingBox()
+  const initialRailBox = await rail.boundingBox()
+  expect(initialDialogBox).not.toBeNull()
+  expect(initialRailBox).not.toBeNull()
+  expect(initialDialogBox!.y).toBeCloseTo(80, 0)
+  expect(initialRailBox!.x - (initialDialogBox!.x + initialDialogBox!.width)).toBeCloseTo(16, 0)
+  expect(initialRailBox!.y + initialRailBox!.height / 2 - initialDialogBox!.y).toBeCloseTo(128, 0)
+
+  await next.click()
+  await next.click()
+  await expect(dialog.locator(".preview-gallery-count")).toHaveText("3 / 12")
+
+  const changedDialogBox = await dialog.boundingBox()
+  const changedRailBox = await rail.boundingBox()
+  expect(changedDialogBox).not.toBeNull()
+  expect(changedRailBox).not.toBeNull()
+  expect(changedDialogBox!.y).toBeCloseTo(initialDialogBox!.y, 0)
+  expect(changedRailBox!.x).toBeCloseTo(initialRailBox!.x, 0)
+  expect(changedRailBox!.y).toBeCloseTo(initialRailBox!.y, 0)
+
+  await previous.click()
+  await expect(dialog.locator(".preview-gallery-count")).toHaveText("2 / 12")
+})
+
 test("keeps a semantic disclosure control while work-history details are expanded", async ({ page }) => {
   await page.goto("/")
   const disclosure = page.getByRole("button", { name: "0x.org and Matcha.xyz" })


### PR DESCRIPTION
Adds accessible desktop up/down controls to the source gallery dialog while preserving the existing mobile toolbar and keyboard shortcuts.

Anchors the modal and controls independently of project height, places the rail near the modal top, and reduces the bottom corner radius to 28px.

Moves modal scrolling onto the card so the external controls stay inside the dialog focus scope without moving with content transitions. Adds Playwright regression coverage for geometry, navigation, and styling; lint, build, and all 13 end-to-end tests pass.