### PR TITLE
Add vertical gallery navigation (source port of #24)

### DIFF
--- a/src/components/PreviewGalleryDialog.tsx
+++ b/src/components/PreviewGalleryDialog.tsx
@@ -1,6 +1,6 @@
 import { Dialog } from "@base-ui/react/dialog"
 import { useSound } from "@web-kits/audio/react"
-import { ChevronLeft, ChevronRight, X } from "lucide-react"
+import { ChevronDown, ChevronLeft, ChevronRight, ChevronUp, X } from "lucide-react"
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from "react"
 
 import type { PortfolioCard } from "../data/portfolio"
@@ -353,8 +353,36 @@ export function PreviewGalleryDialog({
                 </dl>
               </div>
             </article>
-
           </Dialog.Popup>
+
+          {/* A mouse affordance for desktop, where the toolbar is display:none
+              and paging is otherwise Arrow-keys-only. It sits outside the popup
+              (nothing else clears the popup's overflow), so the dialog's focus
+              trap cannot reach it — rather than fight the trap, keep it out of
+              the tab order and the a11y tree. Keyboard and AT users keep the
+              existing Arrow key handler, so this adds reach without taking any
+              away. */}
+          <div className="preview-gallery-rail" aria-hidden="true">
+            <button
+              type="button"
+              tabIndex={-1}
+              className="preview-gallery-nav preview-gallery-nav-previous"
+              onClick={() => moveBy(-1)}
+              disabled={cards.length <= 1}
+            >
+              <ChevronUp aria-hidden="true" strokeWidth={2} className="preview-gallery-nav-icon" />
+            </button>
+
+            <button
+              type="button"
+              tabIndex={-1}
+              className="preview-gallery-nav preview-gallery-nav-next"
+              onClick={() => moveBy(1)}
+              disabled={cards.length <= 1}
+            >
+              <ChevronDown aria-hidden="true" strokeWidth={2} className="preview-gallery-nav-icon" />
+            </button>
+          </div>
         </div>
       </Dialog.Portal>
     </Dialog.Root>

--- a/src/index.css
+++ b/src/index.css
@@ -10,6 +10,7 @@
   --font-secondary: var(--font-newsreader, var(--font-fallback));
   --font-script: var(--font-benji-script, var(--font-fallback));
   --font-code: "SF Mono", "SFMono-Regular", "Consolas", "Liberation Mono", Menlo, Courier, monospace;
+  --preview-gallery-fixed-top: max(8vh, env(safe-area-inset-top));
   --font-body: var(--font-primary);
   --body-color: #111;
   --body-bg: #fdfdfc;
@@ -2103,6 +2104,61 @@ img {
     max(1rem, env(safe-area-inset-bottom))
     max(clamp(1rem, 3vw, 2.5rem), env(safe-area-inset-left));
   cursor: pointer;
+}
+
+/* Pin the popup to a stable offset where there is room for it, so paging
+   between previews of different heights does not shift it up and down. */
+@media (min-width: 721px) and (hover: hover) and (pointer: fine) {
+  .preview-gallery-shell {
+    padding-top: var(--preview-gallery-fixed-top);
+  }
+}
+
+/* Square off the bottom corners a little relative to the top, so the detail
+   block below the media does not read as a floating pill. */
+.preview-gallery-popup,
+.preview-gallery-card {
+  border-bottom-right-radius: 28px;
+  border-bottom-left-radius: 28px;
+}
+
+/* Vertical shortcut rail, pointer-only. The popup is a centred
+   min(544px, 100%), so half of it (272px) plus a 16px gutter puts the rail
+   just off its right edge without measuring anything at runtime. */
+.preview-gallery-rail {
+  position: fixed;
+  z-index: 71;
+  top: calc(var(--preview-gallery-fixed-top) + 128px);
+  left: calc(50% + 288px);
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  transform: translateY(-50%);
+}
+
+.preview-gallery-rail .preview-gallery-nav {
+  background: rgb(255 255 255 / 0.92);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+
+/* No room beside the popup, and no pointer to use it: fall back to the
+   toolbar buttons, turned to match the vertical arrow-key model. */
+@media (max-width: 720px), (hover: none), (pointer: coarse) {
+  .preview-gallery-rail {
+    display: none;
+  }
+
+  .preview-gallery-toolbar .preview-gallery-nav-prev .preview-gallery-nav-icon,
+  .preview-gallery-toolbar .preview-gallery-nav-next .preview-gallery-nav-icon {
+    transform: rotate(90deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .preview-gallery-rail .preview-gallery-nav {
+    transition: none;
+  }
 }
 
 .preview-gallery-popup {

--- a/tests/e2e/portfolio-polish.spec.ts
+++ b/tests/e2e/portfolio-polish.spec.ts
@@ -167,13 +167,20 @@ test("offers a vertical gallery rail on desktop and hides it on touch layouts", 
   const popupBox = await popup.boundingBox()
   expect(Math.round(railBox!.x - (popupBox!.x + popupBox!.width))).toBe(16)
 
+  // moveBy() ignores input while a switch is animating, so wait for the card
+  // to settle between navigations rather than racing the transition.
+  const card = page.locator(".preview-gallery-card")
+  const settled = async () => expect(card).not.toHaveClass(/preview-gallery-card-switch/)
+
   // The count lives in the toolbar, which is touch-only, so assert on the title.
   const title = page.locator(".preview-gallery-title")
   await expect(title).toHaveText("Matcha - Multiwallet flow")
   await rail.locator("button").nth(1).click()
   await expect(title).toHaveText("Matcha - Homepage")
+  await settled()
   await rail.locator("button").first().click()
   await expect(title).toHaveText("Matcha - Multiwallet flow")
+  await settled()
 
   // Pointer-only affordance: the dialog focus trap cannot reach outside the
   // popup, so the rail stays out of the tab order and the a11y tree while

--- a/tests/e2e/portfolio-polish.spec.ts
+++ b/tests/e2e/portfolio-polish.spec.ts
@@ -153,6 +153,40 @@ for (const viewport of [
   })
 }
 
+test("offers a vertical gallery rail on desktop and hides it on touch layouts", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 1000 })
+  await page.goto("/")
+  await page.locator(".mosaic-row-card").first().click()
+
+  const rail = page.locator(".preview-gallery-rail")
+  const popup = page.locator(".preview-gallery-popup")
+  await expect(rail).toBeVisible()
+
+  // The rail is positioned purely in CSS; check it lands beside the popup.
+  const railBox = await rail.boundingBox()
+  const popupBox = await popup.boundingBox()
+  expect(Math.round(railBox!.x - (popupBox!.x + popupBox!.width))).toBe(16)
+
+  // The count lives in the toolbar, which is touch-only, so assert on the title.
+  const title = page.locator(".preview-gallery-title")
+  await expect(title).toHaveText("Matcha - Multiwallet flow")
+  await rail.locator("button").nth(1).click()
+  await expect(title).toHaveText("Matcha - Homepage")
+  await rail.locator("button").first().click()
+  await expect(title).toHaveText("Matcha - Multiwallet flow")
+
+  // Pointer-only affordance: the dialog focus trap cannot reach outside the
+  // popup, so the rail stays out of the tab order and the a11y tree while
+  // Arrow keys remain the keyboard path.
+  await expect(rail).toHaveAttribute("aria-hidden", "true")
+  expect(await rail.getByRole("button").count()).toBe(0)
+  await page.keyboard.press("ArrowDown")
+  await expect(title).toHaveText("Matcha - Homepage")
+
+  await page.setViewportSize(mobileViewport)
+  await expect(rail).toBeHidden()
+})
+
 test("constrains the desktop mosaic at wide viewport sizes", async ({ page }) => {
   await page.setViewportSize({ width: 1920, height: 1080 })
   await page.goto("/")


### PR DESCRIPTION
Replaces #24, which cannot be rebased onto `main`.

#24 was written against `gh-pages`, so its work exists only as built output:
`assets/gallery-vertical-navigation.css`, `assets/gallery-vertical-navigation.js`,
and a `<link>`/`<script>` pair in the generated `index.html`. None of those
files exist on `main`, so there is no commit to replay — the behaviour had to
be rebuilt in `src/`.

### What the port changes

The original script observed the entire document with a `MutationObserver`,
appended a rail to `document.body`, recomputed its position on every resize,
and dispatched **synthetic `KeyboardEvent`s** to trigger navigation. Inside the
dialog component none of that is necessary:

| Original | Ported |
|---|---|
| `MutationObserver` on `document.body` | rendered by React with the dialog |
| `positionRail()` measuring on resize | `left: calc(50% + 288px)` (popup is a centred 544px) |
| synthetic `KeyboardEvent` dispatch | calls `moveBy(±1)` directly |
| manual Tab focus-loop handler | not needed (see below) |

Verified in a browser that the CSS positioning reproduces the original's
JS-computed result exactly: **16px** from the popup's right edge.

### Accessibility note — worth a look

`.preview-gallery-toolbar` is `display: none` except on touch
(`max-width: 699.98px, hover: none, pointer: coarse`), so on desktop there are
no visible nav controls today and paging is Arrow-keys-only.

The rail must sit outside the popup (nothing else clears the popup's
`overflow`), and the dialog's focus trap does not extend outside it — I
confirmed with real Tab presses that focus cycles within the popup only. That
is what #24's `handleFocusLoop` was working around. Rather than fight the trap,
the rail is `aria-hidden` and out of the tab order: it adds a **mouse** path
while keyboard and AT users keep the Arrow key handler they already had. No
accessible behaviour is removed.

If you'd rather the rail be focusable, the clean fix is to show the toolbar on
desktop instead of floating a second control set outside the dialog — happy to
do that instead.

### Also carried over

Stable top offset so paging between previews of different heights no longer
shifts the popup, softened bottom corners, and toolbar icons rotated 90° on
touch to match the vertical arrow model.

### Verification

`npm run lint`, `npm run build`, and 13/13 Playwright tests pass, including a
new test covering rail placement, paging in both directions, the `aria-hidden`
contract, Arrow-key fallback, and the mobile hide.

Closes #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)