### PR TITLE
Polish gallery modal transitions

### DIFF
--- a/src/components/PreviewGalleryDialog.tsx
+++ b/src/components/PreviewGalleryDialog.tsx
@@ -23,27 +23,141 @@ const previewSwitchExitMs = 190
 const previewCloseResetMs = 260
 
 // Origin-aware open/close: the popup travels from (and back to) the card that
-// was clicked, so the modal reads as that card growing into place.
-const originOpenMs = 320
-const originCloseMs = 210
-const originOpenEasing = "cubic-bezier(0.16, 1, 0.3, 1)"
-const originCloseEasing = "cubic-bezier(0.5, 0, 0.35, 1)"
-// Used when the anchor card is off-screen: a plain lift, no travel.
-const originFallbackTransform = "translate3d(0, 1.25rem, 0) scale(0.96)"
+// was clicked, so the modal reads as that card growing into place. Every
+// duration and curve it uses lives in this block, including the ones only the
+// stylesheet needs — those are handed to CSS as custom properties below, so the
+// JS and CSS halves of the animation cannot drift apart.
+
+// The open is deliberately not an expo-out. A quintic curve is 97% done in its
+// first third, which for a surface growing out of a card means the growth is
+// over before the eye catches it and the rest of the duration is dead air. This
+// one spends its time where the size change is actually visible, then settles.
+const openEasePoints = [0.32, 0.8, 0.32, 1] as const
+const closeEasePoints = [0.4, 0, 1, 1] as const
+const toCssEasing = (points: readonly number[]) => `cubic-bezier(${points.join(", ")})`
+
+const galleryMotion = {
+  openMs: 200,
+  closeMs: 150,
+  openEase: toCssEasing(openEasePoints),
+  closeEase: toCssEasing(closeEasePoints),
+  contentInMs: 140,
+  contentOutMs: 120,
+  backdropInMs: 180,
+  backdropOutMs: 150,
+  switchMs: previewSwitchExitMs,
+}
+
+const galleryMotionVars = {
+  "--pg-open-ms": `${galleryMotion.openMs}ms`,
+  "--pg-close-ms": `${galleryMotion.closeMs}ms`,
+  "--pg-open-ease": galleryMotion.openEase,
+  "--pg-close-ease": galleryMotion.closeEase,
+  "--pg-content-in-ms": `${galleryMotion.contentInMs}ms`,
+  "--pg-content-out-ms": `${galleryMotion.contentOutMs}ms`,
+  "--pg-backdrop-in-ms": `${galleryMotion.backdropInMs}ms`,
+  "--pg-backdrop-out-ms": `${galleryMotion.backdropOutMs}ms`,
+  "--pg-switch-ms": `${galleryMotion.switchMs}ms`,
+} as CSSProperties
+
+// Not a full flight from the card to the centre. Replaying the whole distance
+// reads as a journey — the modal has to cross the page, so it needs a long
+// duration to not feel thrown, and the wait is worse than the payoff. Instead
+// the travel is capped: enough to say "from over there" as the surface settles,
+// then it is out of the way. The direction survives the cap, the distance does
+// not.
+const originMaxTravel = 44
+const originScaleMin = 0.92
+const originScaleMax = 1
+// Used when the anchor card is off-screen: a plain 20px lift, no travel.
+const originFallback = { dx: 0, dy: 20, scale: 0.96 }
 
 const useIsomorphicLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect
 
-function getOriginTransform(originRect: DOMRect, targetRect: DOMRect) {
+function getOriginOffset(originRect: DOMRect, targetRect: DOMRect) {
   if (targetRect.width <= 0 || targetRect.height <= 0) return null
   if (originRect.width <= 0 || originRect.height <= 0) return null
 
-  // Clamped tighter than a strict FLIP would be: the extremes read as a lurch,
-  // and the point is to hint at the origin, not to replay the geometry exactly.
-  const scale = Math.min(Math.max(originRect.width / targetRect.width, 0.55), 1.02)
+  // Clamped rather than a strict FLIP: the point is to hint at the origin, not
+  // to replay the geometry exactly.
+  const scale = Math.min(Math.max(originRect.width / targetRect.width, originScaleMin), originScaleMax)
   const dx = originRect.left + originRect.width / 2 - (targetRect.left + targetRect.width / 2)
   const dy = originRect.top + originRect.height / 2 - (targetRect.top + targetRect.height / 2)
 
-  return `translate3d(${dx.toFixed(2)}px, ${dy.toFixed(2)}px, 0) scale(${scale.toFixed(4)})`
+  // Keep the bearing, drop the distance: a card in the far corner and one just
+  // below the fold should both nudge in by the same amount, differing only in
+  // which way they come from.
+  const distance = Math.hypot(dx, dy)
+  const cap = distance > originMaxTravel ? originMaxTravel / distance : 1
+
+  return { dx: dx * cap, dy: dy * cap, scale }
+}
+
+// cubic-bezier(x1, y1, x2, y2) evaluated as a progress function.
+function cubicBezierEasing([x1, y1, x2, y2]: readonly number[]) {
+  const axis = (a: number, b: number, t: number) =>
+    3 * a * (1 - t) * (1 - t) * t + 3 * b * (1 - t) * t * t + t * t * t
+
+  return (x: number) => {
+    if (x <= 0) return 0
+    if (x >= 1) return 1
+
+    let low = 0
+    let high = 1
+    let t = x
+    // Bisection: 24 rounds is far inside a sub-pixel and costs nothing at the
+    // ~50 samples we take per open.
+    for (let round = 0; round < 24; round += 1) {
+      if (axis(x1, x2, t) < x) low = t
+      else high = t
+      t = (low + high) / 2
+    }
+    return axis(y1, y2, t)
+  }
+}
+
+const easeOpen = cubicBezierEasing(openEasePoints)
+const easeClose = cubicBezierEasing(closeEasePoints)
+
+// Enough samples that the linear interpolation between them is invisible at
+// 120Hz over the longest of these animations.
+const originSampleCount = 48
+
+// The wrapper scales the surface by `s` and the inner layer has to undo it with
+// `1/s`. Easing those two independently does NOT cancel — lerp(s, 1) times
+// lerp(1/s, 1) peaks around 20% off at the midpoint, which shows up as the copy
+// visibly breathing. So the easing is baked into sampled keyframes here and both
+// animations run `linear`, which keeps them exact reciprocals at every offset.
+function buildOriginKeyframes(
+  mode: "open" | "close",
+  offset: { dx: number; dy: number; scale: number },
+) {
+  const ease = mode === "open" ? easeOpen : easeClose
+  const wrap: Keyframe[] = []
+  const inner: Keyframe[] = []
+
+  for (let step = 0; step < originSampleCount; step += 1) {
+    const time = step / (originSampleCount - 1)
+    // `travel` is 0 at the origin card and 1 at the modal's resting place.
+    const eased = ease(time)
+    const travel = mode === "open" ? eased : 1 - eased
+    const scale = offset.scale + (1 - offset.scale) * travel
+    const dx = offset.dx * (1 - travel)
+    const dy = offset.dy * (1 - travel)
+
+    wrap.push({
+      offset: time,
+      easing: "linear",
+      transform: `translate3d(${dx.toFixed(2)}px, ${dy.toFixed(2)}px, 0) scale(${scale.toFixed(5)})`,
+    })
+    inner.push({
+      offset: time,
+      easing: "linear",
+      transform: `scale(${(1 / scale).toFixed(5)})`,
+    })
+  }
+
+  return { wrap, inner }
 }
 
 function isVideoPreviewSource(source: string) {
@@ -110,7 +224,8 @@ export function PreviewGalleryDialog({
   const switchFrameRef = useRef<number | null>(null)
   const closeResetTimeoutRef = useRef<number | null>(null)
   const originWrapRef = useRef<HTMLDivElement | null>(null)
-  const originAnimationRef = useRef<Animation | null>(null)
+  const cardInnerRef = useRef<HTMLDivElement | null>(null)
+  const originAnimationsRef = useRef<Animation[]>([])
   // The portal mounts its contents in a later commit than the one that flips
   // `open`, so the open animation keys off the node arriving, not off `open`.
   const [originWrapNode, setOriginWrapNode] = useState<HTMLDivElement | null>(null)
@@ -176,6 +291,20 @@ export function PreviewGalleryDialog({
     originInputsRef.current = { getOriginRect, prefersReducedMotion, safeIndex }
   }, [getOriginRect, prefersReducedMotion, safeIndex])
 
+  // A translated (and counter-scaled) child overflows its scroll containers,
+  // which would flash a scrollbar mid-flight, and the rail would ride the scale
+  // down to a speck. One flag on the shell gates both, plus the compositing
+  // hints, and it must come off however the animation ends.
+  const clearOriginAnimatingFlag = useCallback(() => {
+    originWrapRef.current?.parentElement?.removeAttribute("data-origin-animating")
+  }, [])
+
+  const cancelOriginAnimations = useCallback(() => {
+    for (const animation of originAnimationsRef.current) animation.cancel()
+    originAnimationsRef.current = []
+    clearOriginAnimatingFlag()
+  }, [clearOriginAnimatingFlag])
+
   const runOriginAnimation = useCallback((mode: "open" | "close") => {
     const wrap = originWrapRef.current
     const { getOriginRect: originRectAt, prefersReducedMotion: reducedMotion, safeIndex: index } =
@@ -183,37 +312,45 @@ export function PreviewGalleryDialog({
     if (!wrap || reducedMotion || !originRectAt) return
     if (typeof wrap.animate !== "function") return
 
-    originAnimationRef.current?.cancel()
-    originAnimationRef.current = null
+    cancelOriginAnimations()
 
     // The wrapper sits at rest here (any in-flight animation was cancelled),
     // so this is its untransformed target geometry.
     const originRect = originRectAt(index)
-    const transform =
-      (originRect && getOriginTransform(originRect, wrap.getBoundingClientRect())) ?? originFallbackTransform
+    const offset =
+      (originRect && getOriginOffset(originRect, wrap.getBoundingClientRect())) ?? originFallback
+    const keyframes = buildOriginKeyframes(mode, offset)
 
-    const frames = mode === "open" ? [transform, "none"] : ["none", transform]
-
-    const animation = wrap.animate(
-      frames.map((value) => ({ transform: value })),
-      {
-        duration: mode === "open" ? originOpenMs : originCloseMs,
-        easing: mode === "open" ? originOpenEasing : originCloseEasing,
-        fill: mode === "open" ? "none" : "forwards",
-      },
-    )
-    originAnimationRef.current = animation
-
-    // A translated child grows the scroll container, which would flash a
-    // scrollbar mid-flight. Lock the shell until the travel lands.
-    const shell = wrap.parentElement
-    shell?.setAttribute("data-origin-animating", "true")
-    if (mode === "open") {
-      animation.finished
-        .then(() => shell?.removeAttribute("data-origin-animating"))
-        .catch(() => undefined)
+    const options: KeyframeAnimationOptions = {
+      duration: mode === "open" ? galleryMotion.openMs : galleryMotion.closeMs,
+      // The curve is already baked into the keyframes.
+      easing: "linear",
+      fill: mode === "open" ? "none" : "forwards",
     }
-  }, [])
+
+    const travel = wrap.animate(keyframes.wrap, options)
+    originAnimationsRef.current = [travel]
+
+    // The surface scales, the content must not: this layer takes the exact
+    // reciprocal, so the copy and the media sit at final size the whole way and
+    // the growing box simply reveals them. Same start time, so the two
+    // transforms cancel on every frame.
+    const inner = cardInnerRef.current
+    if (inner && typeof inner.animate === "function") {
+      const counter = inner.animate(keyframes.inner, options)
+      if (travel.startTime !== null) counter.startTime = travel.startTime
+      originAnimationsRef.current.push(counter)
+    }
+
+    wrap.parentElement?.setAttribute("data-origin-animating", "true")
+    // Only the open path unlocks on finish. On close the transform is held by
+    // `fill: forwards` until Base UI unmounts, so releasing the clip early would
+    // flash the very scrollbar the flag exists to suppress; the next
+    // `cancelOriginAnimations` clears it instead.
+    if (mode === "open") {
+      travel.finished.then(clearOriginAnimatingFlag).catch(() => undefined)
+    }
+  }, [cancelOriginAnimations, clearOriginAnimatingFlag])
 
   const attachOriginWrap = useCallback((node: HTMLDivElement | null) => {
     originWrapRef.current = node
@@ -227,9 +364,9 @@ export function PreviewGalleryDialog({
 
   useEffect(() => {
     return () => {
-      originAnimationRef.current?.cancel()
+      cancelOriginAnimations()
     }
-  }, [])
+  }, [cancelOriginAnimations])
 
   const handleOpenChange = useCallback(
     (nextOpen: boolean) => {
@@ -324,10 +461,11 @@ export function PreviewGalleryDialog({
   return (
     <Dialog.Root open={open} onOpenChange={handleOpenChange}>
       <Dialog.Portal>
-        <Dialog.Backdrop className="preview-gallery-backdrop" />
+        <Dialog.Backdrop className="preview-gallery-backdrop" style={galleryMotionVars} />
 
         <div
           className="preview-gallery-shell"
+          style={galleryMotionVars}
           onMouseDown={(event) => {
             if (event.target === event.currentTarget) {
               handleOpenChange(false)
@@ -342,115 +480,117 @@ export function PreviewGalleryDialog({
               aria-label={`${activeCard.title} gallery preview`}
             >
               <article className={`preview-gallery-card${switchClassName}`}>
-                <div
-                  className="preview-gallery-media-frame"
-                  style={mediaFrameStyle}
-                  onTouchStart={(event) => {
-                    touchStartXRef.current = event.changedTouches[0]?.clientX ?? null
-                  }}
-                  onTouchEnd={(event) => {
-                    const touchStartX = touchStartXRef.current
-                    if (touchStartX == null) return
+                <div className="preview-gallery-card-inner" ref={cardInnerRef}>
+                  <div
+                    className="preview-gallery-media-frame"
+                    style={mediaFrameStyle}
+                    onTouchStart={(event) => {
+                      touchStartXRef.current = event.changedTouches[0]?.clientX ?? null
+                    }}
+                    onTouchEnd={(event) => {
+                      const touchStartX = touchStartXRef.current
+                      if (touchStartX == null) return
 
-                    const touchEndX = event.changedTouches[0]?.clientX ?? touchStartX
-                    const delta = touchEndX - touchStartX
-                    const threshold = 56
+                      const touchEndX = event.changedTouches[0]?.clientX ?? touchStartX
+                      const delta = touchEndX - touchStartX
+                      const threshold = 56
 
-                    if (Math.abs(delta) >= threshold) {
-                      moveBy(delta > 0 ? -1 : 1)
-                    }
+                      if (Math.abs(delta) >= threshold) {
+                        moveBy(delta > 0 ? -1 : 1)
+                      }
 
-                    touchStartXRef.current = null
-                  }}
-                >
-                  {activeCardIsVideo ? (
-                    <video
-                      src={activeCard.image}
-                      poster={activeCard.previewPoster}
-                      width={activeCard.previewWidth}
-                      height={activeCard.previewHeight}
-                      muted
-                      loop={!prefersReducedMotion}
-                      autoPlay={!prefersReducedMotion}
-                      playsInline
-                      preload={prefersReducedMotion ? "none" : "metadata"}
-                      controls
-                      aria-label={activeCard.title}
-                      className="preview-gallery-media"
-                    />
-                  ) : (
-                    <img
-                      src={activeCard.image}
-                      alt={activeCard.title}
-                      width={activeCard.previewWidth}
-                      height={activeCard.previewHeight}
-                      className="preview-gallery-media"
-                      loading="eager"
-                      decoding="async"
-                    />
-                  )}
-                </div>
-
-                <div className="preview-gallery-toolbar">
-                  <span className="preview-gallery-count">
-                    {safeIndex + 1} / {cards.length}
-                  </span>
-
-                  <div className="preview-gallery-controls" aria-label="Preview controls">
-                    <button
-                      type="button"
-                      className="preview-gallery-nav preview-gallery-nav-prev"
-                      aria-label="Previous preview"
-                      aria-keyshortcuts="ArrowUp ArrowLeft"
-                      onClick={() => moveBy(-1)}
-                      disabled={cards.length <= 1}
-                    >
-                      <ChevronLeft aria-hidden="true" strokeWidth={2} className="preview-gallery-nav-icon" />
-                    </button>
-
-                    <button
-                      type="button"
-                      className="preview-gallery-nav preview-gallery-nav-next"
-                      aria-label="Next preview"
-                      aria-keyshortcuts="ArrowDown ArrowRight"
-                      onClick={() => moveBy(1)}
-                      disabled={cards.length <= 1}
-                    >
-                      <ChevronRight aria-hidden="true" strokeWidth={2} className="preview-gallery-nav-icon" />
-                    </button>
-
-                    <Dialog.Close className="preview-gallery-nav preview-gallery-close" aria-label="Close preview">
-                      <X aria-hidden="true" strokeWidth={2} className="preview-gallery-nav-icon" />
-                    </Dialog.Close>
+                      touchStartXRef.current = null
+                    }}
+                  >
+                    {activeCardIsVideo ? (
+                      <video
+                        src={activeCard.image}
+                        poster={activeCard.previewPoster}
+                        width={activeCard.previewWidth}
+                        height={activeCard.previewHeight}
+                        muted
+                        loop={!prefersReducedMotion}
+                        autoPlay={!prefersReducedMotion}
+                        playsInline
+                        preload={prefersReducedMotion ? "none" : "metadata"}
+                        controls
+                        aria-label={activeCard.title}
+                        className="preview-gallery-media"
+                      />
+                    ) : (
+                      <img
+                        src={activeCard.image}
+                        alt={activeCard.title}
+                        width={activeCard.previewWidth}
+                        height={activeCard.previewHeight}
+                        className="preview-gallery-media"
+                        loading="eager"
+                        decoding="async"
+                      />
+                    )}
                   </div>
-                </div>
 
-                <div className="preview-gallery-content">
-                  <div className="preview-gallery-heading">
-                    <div>
-                      <Dialog.Title className="preview-gallery-title">{activeCard.title}</Dialog.Title>
-                      <Dialog.Description className="preview-gallery-description">{activeDescription}</Dialog.Description>
+                  <div className="preview-gallery-toolbar">
+                    <span className="preview-gallery-count">
+                      {safeIndex + 1} / {cards.length}
+                    </span>
+
+                    <div className="preview-gallery-controls" aria-label="Preview controls">
+                      <button
+                        type="button"
+                        className="preview-gallery-nav preview-gallery-nav-prev"
+                        aria-label="Previous preview"
+                        aria-keyshortcuts="ArrowUp ArrowLeft"
+                        onClick={() => moveBy(-1)}
+                        disabled={cards.length <= 1}
+                      >
+                        <ChevronLeft aria-hidden="true" strokeWidth={2} className="preview-gallery-nav-icon" />
+                      </button>
+
+                      <button
+                        type="button"
+                        className="preview-gallery-nav preview-gallery-nav-next"
+                        aria-label="Next preview"
+                        aria-keyshortcuts="ArrowDown ArrowRight"
+                        onClick={() => moveBy(1)}
+                        disabled={cards.length <= 1}
+                      >
+                        <ChevronRight aria-hidden="true" strokeWidth={2} className="preview-gallery-nav-icon" />
+                      </button>
+
+                      <Dialog.Close className="preview-gallery-nav preview-gallery-close" aria-label="Close preview">
+                        <X aria-hidden="true" strokeWidth={2} className="preview-gallery-nav-icon" />
+                      </Dialog.Close>
                     </div>
                   </div>
 
-                  <dl className="preview-gallery-details">
-                    {activeMetaRows.map(([label, value]) => (
-                      <div key={label} className="preview-gallery-detail-row">
-                        <dt>{label}</dt>
-                        <dd>{value}</dd>
+                  <div className="preview-gallery-content">
+                    <div className="preview-gallery-heading">
+                      <div>
+                        <Dialog.Title className="preview-gallery-title">{activeCard.title}</Dialog.Title>
+                        <Dialog.Description className="preview-gallery-description">{activeDescription}</Dialog.Description>
                       </div>
-                    ))}
-                    {activeLink ? (
-                      <div className="preview-gallery-detail-row">
-                        <dt>Link</dt>
-                        <dd>
-                          <a href={activeLink} target="_blank" rel="noreferrer">
-                            {activeLink.replace(/^https?:\/\//, "")}
-                          </a>
-                        </dd>
-                      </div>
-                    ) : null}
-                  </dl>
+                    </div>
+
+                    <dl className="preview-gallery-details">
+                      {activeMetaRows.map(([label, value]) => (
+                        <div key={label} className="preview-gallery-detail-row">
+                          <dt>{label}</dt>
+                          <dd>{value}</dd>
+                        </div>
+                      ))}
+                      {activeLink ? (
+                        <div className="preview-gallery-detail-row">
+                          <dt>Link</dt>
+                          <dd>
+                            <a href={activeLink} target="_blank" rel="noreferrer">
+                              {activeLink.replace(/^https?:\/\//, "")}
+                            </a>
+                          </dd>
+                        </div>
+                      ) : null}
+                    </dl>
+                  </div>
                 </div>
               </article>
 

--- a/src/components/SimpleFeed.tsx
+++ b/src/components/SimpleFeed.tsx
@@ -5,9 +5,22 @@ import { homeRows, type PortfolioCard, type SiteLinks } from "../data/portfolio"
 import { trackEvent } from "../lib/analytics"
 import { WorkedWithCompaniesInline } from "./WorkedWithCompaniesInline"
 
+const importPreviewGallery = () => import("./PreviewGalleryDialog")
+
 const PreviewGalleryDialog = lazy(() =>
-  import("./PreviewGalleryDialog").then((module) => ({ default: module.PreviewGalleryDialog })),
+  importPreviewGallery().then((module) => ({ default: module.PreviewGalleryDialog })),
 )
+
+// The dialog is split out of the main bundle, so a cold first click pays the
+// fetch before anything moves. Warm it on the first hint of intent instead.
+let previewGalleryPreloaded = false
+function preloadPreviewGallery() {
+  if (previewGalleryPreloaded) return
+  previewGalleryPreloaded = true
+  void importPreviewGallery().catch(() => {
+    previewGalleryPreloaded = false
+  })
+}
 
 type SiteProfile = {
   name: string
@@ -574,6 +587,8 @@ export function SimpleFeed({ cards, profile, links, showProjects = true }: Simpl
                                 else nodes.delete(item.previewIndex)
                               }}
                               className={`mosaic-row-card mosaic-row-card-${item.card.id}${isPaginatedCard ? " mosaic-row-card-paginated" : ""}`}
+                              onPointerEnter={isPaginatedCard ? undefined : preloadPreviewGallery}
+                              onFocus={isPaginatedCard ? undefined : preloadPreviewGallery}
                               onClick={() => {
                                 if (isPaginatedCard) {
                                   paginatePreviewCard(

--- a/src/index.css
+++ b/src/index.css
@@ -2460,12 +2460,18 @@ img {
   cursor: pointer;
   backdrop-filter: blur(10px) saturate(0.92);
   -webkit-backdrop-filter: blur(10px) saturate(0.92);
-  transition: opacity 180ms ease-out;
+  /* Opacity only. Ramping `backdrop-filter` re-blurs the whole viewport every
+     frame, which is not worth it — a longer fade already takes off the snap. */
+  transition: opacity var(--pg-backdrop-in-ms, 180ms) ease-out;
 }
 
 .preview-gallery-backdrop[data-starting-style],
 .preview-gallery-backdrop[data-ending-style] {
   opacity: 0;
+}
+
+.preview-gallery-backdrop[data-ending-style] {
+  transition: opacity var(--pg-backdrop-out-ms, 150ms) ease-in;
 }
 
 .preview-gallery-shell {
@@ -2492,7 +2498,7 @@ img {
 }
 
 /* Carries the origin-aware travel (card -> centre) so the popup keeps its own
-   fade/scale transition. Driven by the Web Animations API in the dialog. */
+   fade. Driven by the Web Animations API in the dialog. */
 .preview-gallery-origin-wrap {
   display: flex;
   flex-direction: column;
@@ -2514,35 +2520,50 @@ img {
   transform: translateY(0) scale(1);
   transform-origin: center center;
   transition:
-    opacity 180ms ease-out,
-    transform 220ms cubic-bezier(0.2, 0, 0, 1);
+    opacity var(--pg-content-in-ms, 140ms) ease-out,
+    transform var(--pg-open-ms, 200ms) var(--pg-open-ease, cubic-bezier(0.32, 0.8, 0.32, 1));
 }
 
+/* Fallback for when there is no card to travel from (it scrolled off-screen, or
+   motion is reduced): a plain lift, owned entirely by CSS. */
 .preview-gallery-popup[data-starting-style],
 .preview-gallery-popup[data-ending-style] {
   opacity: 0;
   transform: translateY(1.25rem) scale(0.96);
 }
 
+.preview-gallery-popup[data-ending-style] {
+  transition:
+    opacity var(--pg-content-out-ms, 120ms) ease-in,
+    transform var(--pg-close-ms, 150ms) var(--pg-close-ease, cubic-bezier(0.4, 0, 1, 1));
+}
+
+/* Shrinking a playing video reads as a glitch, so it only fades. */
 .preview-gallery-popup[data-preview-media="video"][data-ending-style] {
   transform: translateY(0) scale(1);
 }
 
 /* When the wrapper is doing the positional travel, the popup only cross-fades —
    its own translate/scale would fight the origin animation. */
+.preview-gallery-popup[data-origin-motion],
+.preview-gallery-popup[data-origin-motion][data-starting-style],
+.preview-gallery-popup[data-origin-motion][data-ending-style] {
+  transform: none;
+}
+
 .preview-gallery-popup[data-origin-motion] {
-  transition: opacity 150ms ease-out;
+  transition: opacity var(--pg-content-in-ms, 140ms) ease-out;
 }
 
 .preview-gallery-popup[data-origin-motion][data-starting-style] {
   opacity: 0;
-  transform: none;
 }
 
+/* Base UI unmounts the popup when this transition ends, so on close it has to
+   outlast the wrapper's travel rather than merely match the content fade. */
 .preview-gallery-popup[data-origin-motion][data-ending-style] {
   opacity: 0;
-  transform: none;
-  transition: opacity 220ms cubic-bezier(0.5, 0, 0.35, 1);
+  transition: opacity var(--pg-close-ms, 150ms) var(--pg-close-ease, cubic-bezier(0.4, 0, 1, 1));
 }
 
 .preview-gallery-card {
@@ -2561,13 +2582,34 @@ img {
   outline: none;
   opacity: 1;
   transform: translateY(0) scale(1);
+  /* This transition belongs to the between-previews switch below, which is
+     stepped by a JS timer — hence the shared duration. */
   transition:
-    opacity 180ms ease-out,
-    transform 220ms cubic-bezier(0.2, 0, 0, 1);
+    opacity var(--pg-switch-ms, 190ms) ease-out,
+    transform var(--pg-switch-ms, 190ms) cubic-bezier(0.2, 0, 0, 1);
   box-shadow:
     0 1px 1px rgb(0 0 0 / 0.04),
     0 18px 44px -18px rgb(0 0 0 / 0.28),
     0 48px 92px -42px rgb(0 0 0 / 0.38);
+}
+
+/* The wrapper scales the surface down to the size of the card that was clicked;
+   this layer takes the exact reciprocal, so the media and the copy sit at final
+   size for the whole flight and the growing box just reveals them. Driven by
+   the Web Animations API in the dialog, in lockstep with the wrapper. */
+.preview-gallery-card-inner {
+  transform-origin: top center;
+}
+
+/* Mid-flight the counter-scaled content overflows its box, so the shell flags
+   the travel and the surface clips rather than flashing a scrollbar. */
+.preview-gallery-shell[data-origin-animating] .preview-gallery-card {
+  overflow: hidden;
+}
+
+.preview-gallery-shell[data-origin-animating] .preview-gallery-origin-wrap,
+.preview-gallery-shell[data-origin-animating] .preview-gallery-card-inner {
+  will-change: transform;
 }
 
 .preview-gallery-card-switch-out-up {
@@ -3152,9 +3194,6 @@ img {
   .preview-gallery-card {
     --preview-gallery-card-padding: 0.85rem;
     --preview-gallery-media-radius: 16px;
-  }
-
-  .preview-gallery-media-frame {
   }
 
   .preview-gallery-media {

--- a/tests/e2e/portfolio-polish.spec.ts
+++ b/tests/e2e/portfolio-polish.spec.ts
@@ -24,12 +24,18 @@ test("keeps gallery controls inside the mobile viewport and exposes a close butt
 
   const dialog = page.getByRole("dialog")
   await expect(dialog).toBeVisible()
-  await expect(dialog).toHaveCSS("transform", "matrix(1, 0, 0, 1, 0, 0)")
+  // All positional travel belongs to the wrapper, so the popup itself is never
+  // transformed while origin motion is on.
+  await expect(dialog).toHaveCSS("transform", "none")
 
   // The gallery flies in from the card it was opened from; measure it at rest.
   await page
     .locator(".preview-gallery-origin-wrap")
     .evaluate((element) => Promise.all(element.getAnimations().map((animation) => animation.finished)))
+
+  // The counter-scale has to land exactly back on identity, or the content is
+  // left a fraction of a percent off its true size.
+  await expect(page.locator(".preview-gallery-card-inner")).toHaveCSS("transform", "none")
 
   for (const name of ["Previous preview", "Next preview", "Close preview"]) {
     const control = dialog.getByRole("button", { name })


### PR DESCRIPTION
Refines the preview gallery open and close motion with shared timing tokens, capped origin travel, reciprocal content scaling, and compositor-friendly animation handling.

Preloads the lazy gallery module on pointer or keyboard intent so the first interaction starts promptly.

Updates modal CSS for distinct entrance and exit easing, overflow containment, reduced visual scaling, and synchronized transition durations.

Validated with `git diff --check`, `npm run lint`, `npm run build`, and all 13 Playwright end-to-end tests.