### PR TITLE
Make profile name and title an accessible view trigger

### DIFF
--- a/src/components/SimpleFeed.tsx
+++ b/src/components/SimpleFeed.tsx
@@ -349,6 +349,8 @@ export function SimpleFeed({ cards, profile, links, showProjects = true }: Simpl
   const [hasSwapped, setHasSwapped] = useState(false)
   const swapTimeoutRef = useRef<number | null>(null)
   const avatarRef = useRef<HTMLButtonElement | null>(null)
+  const viewTriggerRef = useRef<HTMLElement | null>(null)
+  const metaPointerRef = useRef<{ x: number; y: number } | null>(null)
   const [loadedSources, setLoadedSources] = useState<Set<string>>(() => new Set())
   const markLoaded = (src: string) =>
     setLoadedSources((prev) => (prev.has(src) ? prev : new Set(prev).add(src)))
@@ -505,10 +507,10 @@ export function SimpleFeed({ cards, profile, links, showProjects = true }: Simpl
     // eslint-disable-next-line react-hooks/exhaustive-deps -- swapView is redeclared each render
   }, [view, prefersReducedMotion])
 
-  function swapView(nextView: "work" | "about") {
+  function swapView(nextView: "work" | "about", trigger = "avatar") {
     if (nextView === view) return
 
-    trackEvent("hero_view_change", { hero_view: nextView, hero_view_trigger: "avatar" })
+    trackEvent("hero_view_change", { hero_view: nextView, hero_view_trigger: trigger })
 
     // Closing from inside the panel (its back button, or Escape) unmounts
     // whatever had focus, so hand it back to the photo that opened it.
@@ -517,7 +519,7 @@ export function SimpleFeed({ cards, profile, links, showProjects = true }: Simpl
       document.activeElement instanceof Node &&
       (document.getElementById("about-panel")?.contains(document.activeElement) ?? false)
     const restoreFocus = () => {
-      if (focusLeavesWithPanel) avatarRef.current?.focus()
+      if (focusLeavesWithPanel) (viewTriggerRef.current ?? avatarRef.current)?.focus()
     }
 
     if (prefersReducedMotion) {
@@ -553,7 +555,10 @@ export function SimpleFeed({ cards, profile, links, showProjects = true }: Simpl
               aria-expanded={isAboutView}
               aria-controls={isAboutView ? "about-panel" : undefined}
               aria-label={isAboutView ? "Back to selected work" : `Read about ${profile.name}`}
-              onClick={() => swapView(isAboutView ? "work" : "about")}
+              onClick={(event) => {
+                viewTriggerRef.current = event.currentTarget
+                swapView(isAboutView ? "work" : "about")
+              }}
             >
               <div className="mosaic-avatar-coin-inner">
                 <img src={profile.photo} width="208" height="208" alt="" aria-hidden="true" className="mosaic-avatar-face mosaic-avatar-face-front" loading="eager" decoding="async" />
@@ -579,7 +584,37 @@ export function SimpleFeed({ cards, profile, links, showProjects = true }: Simpl
                 </span>
               </span>
             </button>
-            <div className="mosaic-profile-meta">
+            {/* Keep the semantic heading and selectable text while exposing this
+                second hit area as the same accessible disclosure control. */}
+            <div
+              className="mosaic-profile-meta"
+              role="button"
+              tabIndex={0}
+              aria-expanded={isAboutView}
+              aria-controls={isAboutView ? "about-panel" : undefined}
+              aria-label={isAboutView ? "Back to selected work" : `Read about ${profile.name}`}
+              onPointerDown={(event) => {
+                metaPointerRef.current = { x: event.clientX, y: event.clientY }
+              }}
+              onClick={(event) => {
+                // This text stays selectable, so only treat the click as a tap:
+                // a drag that travelled, or one that left a selection behind,
+                // was the reader highlighting their name, not toggling views.
+                const start = metaPointerRef.current
+                metaPointerRef.current = null
+                if (start && Math.hypot(event.clientX - start.x, event.clientY - start.y) > 6) return
+                const selection = window.getSelection()
+                if (selection && !selection.isCollapsed) return
+                viewTriggerRef.current = event.currentTarget
+                swapView(isAboutView ? "work" : "about", "profile-meta")
+              }}
+              onKeyDown={(event) => {
+                if (event.key !== "Enter" && event.key !== " ") return
+                event.preventDefault()
+                viewTriggerRef.current = event.currentTarget
+                swapView(isAboutView ? "work" : "about", "profile-meta")
+              }}
+            >
               <h2>{profile.name}</h2>
               <p className="mosaic-profile-subtitle">{profile.title}</p>
             </div>

--- a/src/index.css
+++ b/src/index.css
@@ -617,6 +617,13 @@ img {
   display: flex;
   flex-direction: column;
   align-items: center;
+  cursor: pointer;
+}
+
+.mosaic-profile-meta:focus-visible {
+  outline: 2px solid #2d2d2d;
+  outline-offset: 3px;
+  border-radius: 0.2rem;
 }
 
 .mosaic-avatar {
@@ -741,6 +748,23 @@ img {
   transform: rotateY(360deg);
 }
 
+/* The name and title toggle the same view, so hovering them plays the photo's
+   flip and reveals its hint as if the photo itself were hovered. */
+.mosaic-profile-info:has(.mosaic-profile-meta:is(:hover, :focus-visible)) .mosaic-avatar-coin-inner {
+  transform: rotateY(180deg);
+}
+
+.mosaic-profile-info:has(.mosaic-profile-meta:is(:hover, :focus-visible))
+  .mosaic-avatar-coin.is-flipped
+  .mosaic-avatar-coin-inner {
+  transform: rotateY(360deg);
+}
+
+.mosaic-profile-info:has(.mosaic-profile-meta:is(:hover, :focus-visible)) .mosaic-avatar-hint {
+  opacity: 1;
+  transform: translateY(-50%) translateX(0) rotate(-3deg);
+}
+
 @media (prefers-reduced-motion: reduce) {
   .mosaic-avatar-coin-inner {
     transition: none;
@@ -749,7 +773,11 @@ img {
   .mosaic-avatar-coin:focus-visible .mosaic-avatar-coin-inner,
   .mosaic-avatar-coin.is-flipped .mosaic-avatar-coin-inner,
   .mosaic-avatar-coin.is-flipped:hover .mosaic-avatar-coin-inner,
-  .mosaic-avatar-coin.is-flipped:focus-visible .mosaic-avatar-coin-inner {
+  .mosaic-avatar-coin.is-flipped:focus-visible .mosaic-avatar-coin-inner,
+  .mosaic-profile-info:has(.mosaic-profile-meta:is(:hover, :focus-visible)) .mosaic-avatar-coin-inner,
+  .mosaic-profile-info:has(.mosaic-profile-meta:is(:hover, :focus-visible))
+    .mosaic-avatar-coin.is-flipped
+    .mosaic-avatar-coin-inner {
     transform: none;
   }
   .mosaic-avatar-button,
@@ -761,7 +789,8 @@ img {
   /* Keep the hint's fade, drop its slide. */
   .mosaic-avatar-hint,
   .mosaic-avatar-button:hover .mosaic-avatar-hint,
-  .mosaic-avatar-button:focus-visible .mosaic-avatar-hint {
+  .mosaic-avatar-button:focus-visible .mosaic-avatar-hint,
+  .mosaic-profile-info:has(.mosaic-profile-meta:is(:hover, :focus-visible)) .mosaic-avatar-hint {
     transform: translateY(-50%) rotate(-3deg);
     transition: opacity 120ms linear;
   }

--- a/tests/e2e/portfolio-polish.spec.ts
+++ b/tests/e2e/portfolio-polish.spec.ts
@@ -17,6 +17,24 @@ test("hydrates the prerendered portfolio without browser errors", async ({ page,
   expect(errors).toEqual([])
 })
 
+test("operates the profile name disclosure from the keyboard and restores focus", async ({ page }) => {
+  await page.goto("/")
+  const trigger = page.locator(".mosaic-profile-meta")
+
+  await expect(trigger).toHaveAttribute("role", "button")
+  await expect(trigger).toHaveAttribute("aria-expanded", "false")
+  await trigger.focus()
+  await trigger.press("Enter")
+
+  await expect(page.locator("#about-panel")).toBeVisible()
+  await expect(page.locator("#about-panel")).toBeFocused()
+  await expect(trigger).toHaveAttribute("aria-expanded", "true")
+
+  await page.keyboard.press("Escape")
+  await expect(page.locator("#about-panel")).toBeHidden()
+  await expect(trigger).toBeFocused()
+})
+
 test("keeps gallery controls inside the mobile viewport and exposes a close button", async ({ page }) => {
   await page.setViewportSize(mobileViewport)
   await page.goto("/")


### PR DESCRIPTION
Makes the profile name and title toggle the About view while preserving selectable text and distinguishing its analytics trigger. Mirrors the avatar hover animation for pointer and keyboard focus, including reduced-motion behavior. Adds accessible disclosure semantics, Enter/Space activation, visible focus, and focus restoration to the originating trigger. Adds Playwright coverage for the keyboard flow; lint, production build, and all 15 end-to-end tests pass.