### PR TITLE
Add adaptive work history popovers

### DIFF
--- a/src/components/HoverLogoLink.tsx
+++ b/src/components/HoverLogoLink.tsx
@@ -1,5 +1,7 @@
 import type { PropsWithChildren } from "react"
 
+import { applyPointerTilt, logoChipTilt, nestedChipTilt, resetPointerTilt } from "../lib/pointerTilt"
+
 type HoverLogoLinkProps = PropsWithChildren<{
   href: string
   logoUrls: string[]
@@ -9,29 +11,18 @@ type HoverLogoLinkProps = PropsWithChildren<{
 }>
 
 function handlePointerMove(event: React.PointerEvent<HTMLAnchorElement>) {
-  const rect = event.currentTarget.getBoundingClientRect()
-  const relativeX = rect.width === 0 ? 0 : (event.clientX - rect.left) / rect.width - 0.5
-  const relativeY = rect.height === 0 ? 0 : (event.clientY - rect.top) / rect.height - 0.5
+  const target = event.currentTarget
+  const box = target.getBoundingClientRect()
 
-  event.currentTarget.style.setProperty("--mosaic-hover-anchor-x", `${(relativeX * 12).toFixed(2)}px`)
-  event.currentTarget.style.setProperty("--mosaic-hover-anchor-y", `${(relativeY * 4).toFixed(2)}px`)
-  event.currentTarget.style.setProperty("--mosaic-hover-tilt-x", `${(-relativeY * 4).toFixed(2)}deg`)
-  event.currentTarget.style.setProperty("--mosaic-hover-tilt-y", `${(relativeX * 8).toFixed(2)}deg`)
-  event.currentTarget.style.setProperty("--mosaic-hover-lift", `${(1 + Math.abs(relativeX) * 0.01).toFixed(3)}`)
-  event.currentTarget.style.setProperty("--mosaic-hover-chip-tilt-x", `${(-relativeY * 2).toFixed(2)}deg`)
-  event.currentTarget.style.setProperty("--mosaic-hover-chip-tilt-y", `${(relativeX * 4).toFixed(2)}deg`)
-  event.currentTarget.style.setProperty("--mosaic-hover-chip-lift", `${(1 + Math.abs(relativeX) * 0.006).toFixed(3)}`)
+  // The pill leans; the logos inside it lean half as much, so they parallax
+  // against their own container instead of moving as one rigid slab.
+  applyPointerTilt({ target, box, pointer: event, scales: logoChipTilt, prefix: "mosaic-hover" })
+  applyPointerTilt({ target, box, pointer: event, scales: nestedChipTilt, prefix: "mosaic-hover-chip" })
 }
 
 function resetPointerAnchor(event: React.PointerEvent<HTMLAnchorElement>) {
-  event.currentTarget.style.setProperty("--mosaic-hover-anchor-x", "0px")
-  event.currentTarget.style.setProperty("--mosaic-hover-anchor-y", "0px")
-  event.currentTarget.style.setProperty("--mosaic-hover-tilt-x", "0deg")
-  event.currentTarget.style.setProperty("--mosaic-hover-tilt-y", "0deg")
-  event.currentTarget.style.setProperty("--mosaic-hover-lift", "1")
-  event.currentTarget.style.setProperty("--mosaic-hover-chip-tilt-x", "0deg")
-  event.currentTarget.style.setProperty("--mosaic-hover-chip-tilt-y", "0deg")
-  event.currentTarget.style.setProperty("--mosaic-hover-chip-lift", "1")
+  resetPointerTilt(event.currentTarget, "mosaic-hover")
+  resetPointerTilt(event.currentTarget, "mosaic-hover-chip")
 }
 
 export function HoverLogoLink({ href, logoUrls, className, ariaLabel, title, children }: HoverLogoLinkProps) {

--- a/src/components/WorkedWithCompaniesInline.tsx
+++ b/src/components/WorkedWithCompaniesInline.tsx
@@ -1,6 +1,20 @@
-import { Fragment, useEffect, useId, useRef, useState, type CSSProperties, type KeyboardEvent } from "react"
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type FocusEvent,
+  type PointerEvent,
+} from "react"
 
+import { applyPointerTilt, popoverTilt, resetPointerTilt } from "../lib/pointerTilt"
 import { HoverLogoLink } from "./HoverLogoLink"
+
+const popoverTiltPrefix = "mosaic-popover"
 
 type WorkedWithCompany = {
   id: string
@@ -11,7 +25,6 @@ type WorkedWithCompany = {
   relationship: "recent" | "previous" | "additional"
   role: string
   description: string
-  expandedText: string
 }
 
 const workedWithCompanies: WorkedWithCompany[] = [
@@ -24,7 +37,6 @@ const workedWithCompanies: WorkedWithCompany[] = [
     relationship: "recent",
     role: "Product designer",
     description: "Designing product surfaces across the 0x ecosystem.",
-    expandedText: "0x.org and Matcha.xyz, shaping trading experiences for one of the clearest DEX products in crypto.",
   },
   {
     id: "matcha",
@@ -35,7 +47,6 @@ const workedWithCompanies: WorkedWithCompany[] = [
     relationship: "recent",
     role: "Product designer",
     description: "Shaping trading experiences for one of the clearest DEX products in crypto.",
-    expandedText: "0x.org and Matcha.xyz, shaping trading experiences for one of the clearest DEX products in crypto.",
   },
   {
     id: "moodys",
@@ -44,9 +55,8 @@ const workedWithCompanies: WorkedWithCompany[] = [
     logoUrls: ["/logos/moodys.png"],
     href: "https://www.moodys.com",
     relationship: "previous",
-    role: "Product designer",
+    role: "Frontend dev and designer",
     description: "Designed financial product workflows for data-dense, decision-heavy tools.",
-    expandedText: "Moody's, designed financial product workflows for data-dense, decision-heavy tools.",
   },
   {
     id: "twilio",
@@ -56,8 +66,7 @@ const workedWithCompanies: WorkedWithCompany[] = [
     href: "https://www.twilio.com",
     relationship: "previous",
     role: "Product designer",
-    description: "Worked on developer tools and communication platform experiences.",
-    expandedText: "Twilio, rethought developer tools and communication platform experiences.",
+    description: "Rethought developer tools and communication platform experiences.",
   },
   {
     id: "onit",
@@ -66,9 +75,8 @@ const workedWithCompanies: WorkedWithCompany[] = [
     logoUrls: ["/logos/onit.png"],
     href: "https://www.onit.com",
     relationship: "previous",
-    role: "Product designer",
+    role: "Frontend dev and designer",
     description: "Helped make legal operations software easier to navigate and understand.",
-    expandedText: "Onit, helped make legal operations software easier to navigate and understand.",
   },
   {
     id: "chainlink",
@@ -79,7 +87,6 @@ const workedWithCompanies: WorkedWithCompany[] = [
     relationship: "previous",
     role: "Product designer",
     description: "Contributed to Web3 infrastructure interfaces with a focus on clarity and trust.",
-    expandedText: "Chainlink, contributed to Web3 infrastructure interfaces with a focus on clarity and trust.",
   },
   {
     id: "google",
@@ -88,9 +95,8 @@ const workedWithCompanies: WorkedWithCompany[] = [
     logoUrls: ["/logos/Google_logo.svg"],
     href: "https://www.google.com",
     relationship: "additional",
-    role: "Product design collaborator",
+    role: "Design collab",
     description: "Worked alongside product teams on focused interface explorations.",
-    expandedText: "Google, worked alongside product teams on focused interface explorations.",
   },
   {
     id: "patrol",
@@ -99,9 +105,8 @@ const workedWithCompanies: WorkedWithCompany[] = [
     logoUrls: ["/logos/protector.svg", "/logos/patrol.svg"],
     href: "https://protector.so/",
     relationship: "additional",
-    role: "Product design collaborator",
+    role: "Design collab",
     description: "Shaped protection-focused mobile product experiences and interface explorations.",
-    expandedText: "Protector and Patrol, shaped protection-focused mobile product experiences and interface explorations.",
   },
 ]
 
@@ -109,353 +114,389 @@ type WorkedWithCompaniesInlineProps = {
   variant?: "sentence" | "profile"
 }
 
+type PopoverPosition = {
+  arrowX: number
+  side: "above" | "below"
+  x: number
+  y: number
+}
+
 const recentGroupId = "recent-0x-matcha"
-const moreInfoId = "more-info"
-const collapseAnimationMs = 140
-const recentExpandedSegments = [
-  "0x.org and Matcha.xyz, shaping trading experiences",
-  "for one of the clearest DEX products in crypto.",
-]
-const moreInfoSegments = [
-  "I've worked in product design since 2015 and now freelance on focused, high-impact projects.",
-  "You can reach me at @rafaelmedian or hey@rafaelmedina.me",
-]
-const moreInfoLinks: Record<string, string> = {
-  "@rafaelmedian": "https://x.com/rafaelmedian",
-  "hey@rafaelmedina.me": "mailto:hey@rafaelmedina.me",
-}
-const expandedCompanyLinks: Record<string, Record<string, string>> = {
-  [recentGroupId]: {
-    "0x.org": "https://0x.org",
-    "Matcha.xyz,": "https://matcha.xyz",
-  },
-  moodys: {
-    "Moody's,": "https://www.moodys.com",
-  },
-  chainlink: {
-    "Chainlink,": "https://chain.link",
-  },
-  twilio: {
-    "Twilio,": "https://www.twilio.com",
-  },
-  onit: {
-    "Onit,": "https://www.onit.com",
-  },
-  google: {
-    "Google,": "https://www.google.com",
-  },
-  patrol: {
-    Protector: "https://protector.so/",
-    "Patrol,": "https://patrol.so/",
-  },
-}
-const companyExpandedSegments: Record<string, string[]> = {
-  [recentGroupId]: recentExpandedSegments,
-  [moreInfoId]: moreInfoSegments,
-  "0x": recentExpandedSegments,
-  matcha: recentExpandedSegments,
-  moodys: ["Moody's, designed financial product workflows", "for data-dense, decision-heavy tools."],
-  twilio: ["Twilio, rethought developer tools", "and communication platform experiences."],
-  onit: ["Onit, helped make legal operations software", "easier to navigate and understand."],
-  chainlink: ["Chainlink, contributed to Web3 infrastructure interfaces", "with a focus on clarity and trust."],
-  google: ["Google, worked alongside product teams", "on focused interface explorations."],
-  patrol: ["Protector and Patrol, shaped protection-focused", "mobile product experiences and interface explorations."],
+const openDelayMs = 120
+const closeDelayMs = 180
+
+function isHoverCapable() {
+  return typeof window !== "undefined" && window.matchMedia("(hover: hover)").matches
 }
 
-function getExpandedSegmentsForCompanyId(companyId: string | null) {
-  if (!companyId) return []
-  return companyExpandedSegments[companyId] ?? []
-}
-
-function shouldReduceMotion() {
-  return typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches
-}
-
-function getPrecedingWordCount(segments: string[], segmentIndex: number) {
-  return segments
-    .slice(0, segmentIndex)
-    .reduce((wordCount, segment) => wordCount + segment.split(" ").length, 0)
-}
-
-function getWordStyle(wordIndex: number) {
-  return { "--mosaic-word-index": wordIndex } as CSSProperties
+function WorkHistoryTrigger({
+  active,
+  company,
+  descriptionId,
+  popoverId,
+  onBlur,
+  onClick,
+  onFocus,
+  onPointerDown,
+  onPointerEnter,
+  onPointerLeave,
+  onPointerMove,
+  setTrigger,
+}: {
+  active: boolean
+  company: WorkedWithCompany
+  descriptionId: string
+  popoverId: string
+  onBlur: (event: FocusEvent<HTMLElement>) => void
+  onClick: (companyId: string) => void
+  onFocus: (companyId: string) => void
+  onPointerDown: (companyId: string) => void
+  onPointerEnter: (companyId: string) => void
+  onPointerLeave: (event: PointerEvent<HTMLButtonElement>) => void
+  onPointerMove: (event: PointerEvent<HTMLButtonElement>) => void
+  setTrigger: (companyId: string, element: HTMLButtonElement | null) => void
+}) {
+  return (
+    <button
+      ref={(element) => setTrigger(company.id, element)}
+      type="button"
+      className={`mosaic-work-history-chip${active ? " is-active" : ""}`}
+      aria-expanded={active}
+      aria-controls={popoverId}
+      aria-describedby={descriptionId}
+      onClick={() => onClick(company.id)}
+      onFocus={() => onFocus(company.id)}
+      onBlur={onBlur}
+      onPointerDown={() => onPointerDown(company.id)}
+      onPointerEnter={() => onPointerEnter(company.id)}
+      onPointerLeave={onPointerLeave}
+      onPointerMove={onPointerMove}
+    >
+      {company.compactName}
+    </button>
+  )
 }
 
 export function WorkedWithCompaniesInline({ variant = "sentence" }: WorkedWithCompaniesInlineProps) {
-  const disclosureId = useId()
-  const [activeCompanyIds, setActiveCompanyIds] = useState<string[]>([])
-  const [collapsingCompanyIds, setCollapsingCompanyIds] = useState<string[]>([])
-  const collapseTimeoutIdsRef = useRef<Record<string, number>>({})
+  const popoverId = useId()
+  const containerRef = useRef<HTMLDivElement>(null)
+  const popoverRef = useRef<HTMLDivElement>(null)
+  const triggerRefs = useRef(new Map<string, HTMLButtonElement>())
+  const openTimeoutRef = useRef<number | undefined>(undefined)
+  const closeTimeoutRef = useRef<number | undefined>(undefined)
+  const pointerFocusCompanyIdRef = useRef<string | null>(null)
+  const [activeCompanyId, setActiveCompanyId] = useState<string | null>(null)
+  const [isSwitchingCompany, setIsSwitchingCompany] = useState(false)
+  const [position, setPosition] = useState<PopoverPosition>({ arrowX: 192, side: "above", x: 192, y: 0 })
 
-  useEffect(() => {
-    const collapseTimeoutIds = collapseTimeoutIdsRef.current
-
-    return () => {
-      Object.values(collapseTimeoutIds).forEach((timeoutId) => window.clearTimeout(timeoutId))
-    }
-  }, [])
-
-  const closeExpansion = (companyId: string) => {
-    const finishCollapse = () => {
-      setActiveCompanyIds((currentCompanyIds) => currentCompanyIds.filter((currentCompanyId) => currentCompanyId !== companyId))
-      setCollapsingCompanyIds((currentCompanyIds) => currentCompanyIds.filter((currentCompanyId) => currentCompanyId !== companyId))
-      delete collapseTimeoutIdsRef.current[companyId]
-    }
-
-    window.clearTimeout(collapseTimeoutIdsRef.current[companyId])
-
-    if (shouldReduceMotion()) {
-      finishCollapse()
-      return
-    }
-
-    setCollapsingCompanyIds((currentCompanyIds) =>
-      currentCompanyIds.includes(companyId) ? currentCompanyIds : [...currentCompanyIds, companyId],
-    )
-    collapseTimeoutIdsRef.current[companyId] = window.setTimeout(finishCollapse, collapseAnimationMs)
-  }
-
-  const openExpansion = (companyId: string) => {
-    window.clearTimeout(collapseTimeoutIdsRef.current[companyId])
-    delete collapseTimeoutIdsRef.current[companyId]
-    setCollapsingCompanyIds((currentCompanyIds) => currentCompanyIds.filter((currentCompanyId) => currentCompanyId !== companyId))
-    setActiveCompanyIds((currentCompanyIds) => (currentCompanyIds.includes(companyId) ? currentCompanyIds : [...currentCompanyIds, companyId]))
-  }
-
-  if (variant === "profile") {
+  const profileCompanies = useMemo(() => {
     const recentCompanies = workedWithCompanies.filter((company) => company.relationship === "recent")
+    const recentCompany = recentCompanies[1] ?? recentCompanies[0]
+    const recentGroup: WorkedWithCompany | undefined = recentCompany
+      ? {
+          ...recentCompany,
+          id: recentGroupId,
+          name: "0x.org and Matcha.xyz",
+          compactName: "0x.org and Matcha.xyz",
+          logoUrls: recentCompanies.flatMap((company) => company.logoUrls),
+        }
+      : undefined
     const previousCompanyOrder = ["moodys", "chainlink", "twilio", "onit", "google", "patrol"]
     const previousCompanies = previousCompanyOrder.flatMap((companyId) => {
       const company = workedWithCompanies.find((candidate) => candidate.id === companyId)
       return company ? [company] : []
     })
-    const isRecentCompanyActive = activeCompanyIds.includes(recentGroupId)
-    const isMoreInfoActive = activeCompanyIds.includes(moreInfoId)
-    const recentExpandedCompany = recentCompanies[1] ?? recentCompanies[0]
-    const recentCollapsedLabel = "0x.org and Matcha.xyz"
 
-    const toggleCompany = (companyId: string) => {
-      if (activeCompanyIds.includes(companyId)) {
-        closeExpansion(companyId)
+    return { previousCompanies, recentGroup }
+  }, [])
+
+  const activeCompany =
+    activeCompanyId === recentGroupId
+      ? profileCompanies.recentGroup
+      : profileCompanies.previousCompanies.find((company) => company.id === activeCompanyId)
+
+  const clearOpenTimeout = () => window.clearTimeout(openTimeoutRef.current)
+  const clearCloseTimeout = () => window.clearTimeout(closeTimeoutRef.current)
+
+  const closePopover = useCallback(() => {
+    clearOpenTimeout()
+    clearCloseTimeout()
+    setIsSwitchingCompany(false)
+    setActiveCompanyId(null)
+    // Otherwise a keyboard-opened panel inherits the lean from the last hover.
+    if (containerRef.current) resetPointerTilt(containerRef.current, popoverTiltPrefix)
+  }, [])
+
+  const positionPopover = useCallback((companyId: string) => {
+    const container = containerRef.current
+    const popover = popoverRef.current
+    const trigger = triggerRefs.current.get(companyId)
+    if (!container || !popover || !trigger) return
+
+    const containerBox = container.getBoundingClientRect()
+    const triggerBox = trigger.getBoundingClientRect()
+    const popoverWidth = popover.offsetWidth
+    const popoverHeight = popover.offsetHeight
+    const gap = 10
+    const triggerCenter = triggerBox.left - containerBox.left + triggerBox.width / 2
+    const halfPopover = popoverWidth / 2
+    const x = Math.max(halfPopover, Math.min(triggerCenter, containerBox.width - halfPopover))
+    const spaceAbove = triggerBox.top
+    const spaceBelow = window.innerHeight - triggerBox.bottom
+    const side: PopoverPosition["side"] =
+      spaceAbove >= popoverHeight + gap || spaceAbove >= spaceBelow ? "above" : "below"
+    const y =
+      side === "above"
+        ? triggerBox.top - containerBox.top - gap
+        : triggerBox.bottom - containerBox.top + gap
+
+    setPosition({
+      arrowX: triggerCenter - (x - halfPopover),
+      side,
+      x,
+      y,
+    })
+  }, [])
+
+  useLayoutEffect(() => {
+    if (activeCompanyId) positionPopover(activeCompanyId)
+  }, [activeCompanyId, positionPopover])
+
+  useEffect(() => {
+    const handlePositionChange = () => {
+      if (activeCompanyId) positionPopover(activeCompanyId)
+    }
+    const handlePointerDown = (event: globalThis.PointerEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) closePopover()
+    }
+    const handleKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key !== "Escape" || !activeCompanyId) return
+      const activeTrigger = triggerRefs.current.get(activeCompanyId)
+      closePopover()
+      activeTrigger?.focus()
+    }
+
+    window.addEventListener("resize", handlePositionChange)
+    window.addEventListener("scroll", handlePositionChange, { passive: true })
+    document.addEventListener("pointerdown", handlePointerDown)
+    document.addEventListener("keydown", handleKeyDown)
+
+    return () => {
+      window.removeEventListener("resize", handlePositionChange)
+      window.removeEventListener("scroll", handlePositionChange)
+      document.removeEventListener("pointerdown", handlePointerDown)
+      document.removeEventListener("keydown", handleKeyDown)
+    }
+  }, [activeCompanyId, closePopover, positionPopover])
+
+  useEffect(
+    () => () => {
+      clearOpenTimeout()
+      clearCloseTimeout()
+    },
+    [],
+  )
+
+  if (variant === "profile") {
+    /** Let the panel fall flat once the cursor is no longer steering it. */
+    const settleTilt = () => {
+      if (containerRef.current) resetPointerTilt(containerRef.current, popoverTiltPrefix)
+    }
+
+    const openPopover = (companyId: string, delay = false) => {
+      clearCloseTimeout()
+      clearOpenTimeout()
+      if (!delay || activeCompanyId) {
+        setIsSwitchingCompany(activeCompanyId !== null && activeCompanyId !== companyId)
+        setActiveCompanyId(companyId)
         return
       }
-
-      openExpansion(companyId)
+      openTimeoutRef.current = window.setTimeout(() => {
+        setIsSwitchingCompany(false)
+        setActiveCompanyId(companyId)
+      }, openDelayMs)
     }
 
-    const renderWords = (
-      words: string[],
-      keyPrefix: string,
-      { links = {}, wordIndexOffset = 0 }: { links?: Record<string, string>; wordIndexOffset?: number } = {},
-    ) => {
-      const hasLinkedWords = Object.keys(links).length > 0
-
-      return (
-        <span className="mosaic-work-history-chip-copy" aria-hidden={hasLinkedWords ? undefined : true}>
-          {words.map((word, wordIndex) => {
-            const href = links[word]
-            const className = `mosaic-work-history-inline-word${href ? " mosaic-work-history-inline-link" : ""}`
-            const wordStyle = getWordStyle(wordIndexOffset + wordIndex)
-            const children = (
-              <>
-                {word}
-                {wordIndex < words.length - 1 ? "\u00a0" : ""}
-              </>
-            )
-
-            return href ? (
-              <a
-                key={`${keyPrefix}-${word}-${wordIndex}`}
-                href={href}
-                target={href.startsWith("mailto:") ? undefined : "_blank"}
-                rel="noreferrer"
-                className={className}
-                style={wordStyle}
-                onClick={(event) => event.stopPropagation()}
-              >
-                {children}
-              </a>
-            ) : (
-              <span key={`${keyPrefix}-${word}-${wordIndex}`} className={className} style={wordStyle}>
-                {children}
-              </span>
-            )
-          })}
-        </span>
-      )
+    const scheduleClose = () => {
+      clearOpenTimeout()
+      clearCloseTimeout()
+      closeTimeoutRef.current = window.setTimeout(() => {
+        setIsSwitchingCompany(false)
+        setActiveCompanyId(null)
+        settleTilt()
+      }, closeDelayMs)
     }
 
-    const renderExpandedLogos = (company: WorkedWithCompany, logoUrls = company.logoUrls) => {
-      if (logoUrls.length === 0) return null
-
-      return (
-        <span className="mosaic-work-history-expanded-logos" aria-hidden="true">
-          {logoUrls.map((logoUrl) => (
-            <span key={`${company.id}-${logoUrl}`} className="mosaic-work-history-expanded-logo-wrap">
-              <img src={logoUrl} alt="" loading="eager" decoding="async" className="mosaic-work-history-expanded-logo" />
-            </span>
-          ))}
-        </span>
-      )
+    const handleTriggerPointerEnter = (companyId: string) => {
+      if (isHoverCapable()) openPopover(companyId, true)
     }
 
-    const renderExpandedChipContent = (company: WorkedWithCompany) => (
-      <>
-        {renderExpandedLogos(company)}
-        {renderWords(company.expandedText.split(" "), company.id)}
-      </>
-    )
-
-    const handleCollapseKeyDown = (expansionId: string) => (event: KeyboardEvent<HTMLSpanElement>) => {
-      if (event.key !== "Enter" && event.key !== " ") return
-
-      event.preventDefault()
-      closeExpansion(expansionId)
+    const handleTriggerFocus = (companyId: string) => {
+      if (pointerFocusCompanyIdRef.current === companyId) return
+      openPopover(companyId)
     }
 
-    const renderExpandedSegments = ({
-      company,
-      segments,
-      buttonId,
-      logoUrls,
-      keyPrefix,
-      expansionId,
-      collapsedLabel,
-      links,
-      extraClassName = "",
-    }: {
-      company?: WorkedWithCompany
-      segments: string[]
-      buttonId: string
-      logoUrls?: string[]
-      keyPrefix: string
-      expansionId: string
-      collapsedLabel: string
-      links?: Record<string, string>
-      extraClassName?: string
-    }) => {
-      const isCollapsing = collapsingCompanyIds.includes(expansionId)
-
-      return segments.map((segment, segmentIndex) => (
-        <Fragment key={`${keyPrefix}-${segment}`}>
-          {segmentIndex > 0 ? <span className="mosaic-work-history-expanded-break" aria-hidden="true" /> : null}
-          <span
-            id={segmentIndex === 0 ? buttonId : undefined}
-            role="button"
-            tabIndex={0}
-            aria-label={segmentIndex === 0 ? `Collapse ${collapsedLabel} details` : undefined}
-            aria-expanded={segmentIndex === 0 ? true : undefined}
-            aria-controls={segmentIndex === 0 ? buttonId : undefined}
-            className={`mosaic-work-history-chip mosaic-work-history-chip-expanded mosaic-work-history-chip-expanded-segment mosaic-work-history-chip-expanded-collapsible${
-              segmentIndex === 0 ? " mosaic-work-history-chip-expanded-segment-primary" : ""
-            }${extraClassName ? ` ${extraClassName}` : ""}${isCollapsing ? " mosaic-work-history-chip-collapsing" : ""}`}
-            onClick={() => closeExpansion(expansionId)}
-            onKeyDown={handleCollapseKeyDown(expansionId)}
-          >
-            {segmentIndex === 0 && company ? renderExpandedLogos(company, logoUrls) : null}
-            {renderWords(segment.split(" "), `${keyPrefix}-${segmentIndex}`, {
-              links,
-              wordIndexOffset: getPrecedingWordCount(segments, segmentIndex),
-            })}
-          </span>
-        </Fragment>
-      ))
+    const handleTriggerPointerLeave = (event: PointerEvent<HTMLButtonElement>) => {
+      if (!isHoverCapable()) return
+      settleTilt()
+      const destination = event.relatedTarget
+      if (destination instanceof Node && popoverRef.current?.contains(destination)) return
+      scheduleClose()
     }
 
-    const renderMoreInfoExpansion = () =>
-      renderExpandedSegments({
-        segments: moreInfoSegments,
-        buttonId: `${disclosureId}-more-info-expanded`,
-        keyPrefix: moreInfoId,
-        expansionId: moreInfoId,
-        collapsedLabel: "more info",
-        links: moreInfoLinks,
-        extraClassName: "mosaic-work-history-chip-expanded-info",
+    // The popover is a sibling of the triggers, so measure the pointer against
+    // the word it is leaning away from but hang the variables on the shared
+    // container the popover can actually inherit from.
+    const handleTriggerPointerMove = (event: PointerEvent<HTMLButtonElement>) => {
+      const container = containerRef.current
+      if (!container || !isHoverCapable()) return
+
+      applyPointerTilt({
+        target: container,
+        box: event.currentTarget.getBoundingClientRect(),
+        pointer: event,
+        scales: popoverTilt,
+        prefix: popoverTiltPrefix,
       })
-
-    const renderCompanyButton = (company: WorkedWithCompany) => {
-      const isActive = activeCompanyIds.includes(company.id)
-      const companyDisclosureId = `${disclosureId}-${company.id}`
-      const expandedSegments = getExpandedSegmentsForCompanyId(company.id)
-
-      if (isActive && expandedSegments.length > 0) {
-        return renderExpandedSegments({
-          company,
-          segments: expandedSegments,
-          buttonId: companyDisclosureId,
-          keyPrefix: company.id,
-          expansionId: company.id,
-          collapsedLabel: company.compactName,
-          links: expandedCompanyLinks[company.id],
-        })
-      }
-
-      return (
-        <button
-          key={company.id}
-          id={isActive ? companyDisclosureId : undefined}
-          type="button"
-          className={`mosaic-work-history-chip${isActive ? " mosaic-work-history-chip-expanded" : ""}${
-            collapsingCompanyIds.includes(company.id) ? " mosaic-work-history-chip-collapsing" : ""
-          }`}
-          aria-label={isActive ? company.expandedText : undefined}
-          aria-expanded={isActive}
-          onClick={() => toggleCompany(company.id)}
-        >
-          {isActive ? renderExpandedChipContent(company) : company.compactName}
-        </button>
-      )
     }
+
+    const handleFocusLeave = (event: FocusEvent<HTMLElement>) => {
+      const destination = event.relatedTarget
+      if (destination instanceof Node && containerRef.current?.contains(destination)) return
+      closePopover()
+    }
+
+    const setTrigger = (companyId: string, element: HTMLButtonElement | null) => {
+      if (element) triggerRefs.current.set(companyId, element)
+      else triggerRefs.current.delete(companyId)
+    }
+
+    const handleTriggerClick = (companyId: string) => {
+      clearOpenTimeout()
+      clearCloseTimeout()
+      pointerFocusCompanyIdRef.current = null
+      const nextCompanyId = activeCompanyId === companyId ? null : companyId
+      setIsSwitchingCompany(activeCompanyId !== null && nextCompanyId !== null)
+      setActiveCompanyId(nextCompanyId)
+    }
+
+    const popoverStyle = {
+      "--mosaic-popover-arrow-x": `${position.arrowX}px`,
+      "--mosaic-popover-x": `${position.x}px`,
+      "--mosaic-popover-y": `${position.y}px`,
+    } as CSSProperties
 
     return (
-      <div className="mosaic-work-history" aria-label="Work history">
+      <div ref={containerRef} className="mosaic-work-history" aria-label="Work history">
         <div className="mosaic-work-history-line">
           <span className="mosaic-work-history-copy">Recently at</span>
-          {isRecentCompanyActive && recentExpandedCompany ? (
-            <>
-              {renderExpandedSegments({
-                company: recentExpandedCompany,
-                segments: recentExpandedSegments,
-                buttonId: `${disclosureId}-recent-expanded`,
-                logoUrls: recentCompanies.flatMap((company) => company.logoUrls),
-                keyPrefix: recentGroupId,
-                expansionId: recentGroupId,
-                collapsedLabel: recentCollapsedLabel,
-                links: expandedCompanyLinks[recentGroupId],
-              })}
-            </>
-          ) : (
-            <button
-              type="button"
-              className="mosaic-work-history-chip"
-              aria-label={recentCollapsedLabel}
-              aria-expanded="false"
-              aria-controls={`${disclosureId}-recent-expanded`}
-              onClick={() => openExpansion(recentGroupId)}
-            >
-              {recentCollapsedLabel}
-            </button>
-          )}
+          {profileCompanies.recentGroup ? (
+            <WorkHistoryTrigger
+              active={activeCompanyId === profileCompanies.recentGroup.id}
+              company={profileCompanies.recentGroup}
+              descriptionId={`${popoverId}-${profileCompanies.recentGroup.id}-description`}
+              popoverId={popoverId}
+              onBlur={handleFocusLeave}
+              onClick={handleTriggerClick}
+              onFocus={handleTriggerFocus}
+              onPointerDown={(companyId) => {
+                pointerFocusCompanyIdRef.current = companyId
+              }}
+              onPointerEnter={handleTriggerPointerEnter}
+              onPointerLeave={handleTriggerPointerLeave}
+              onPointerMove={handleTriggerPointerMove}
+              setTrigger={setTrigger}
+            />
+          ) : null}
           <span className="mosaic-work-history-copy">previously worked with and at</span>
         </div>
         <div className="mosaic-work-history-line" aria-label="Previous companies">
-          {previousCompanies.map(renderCompanyButton)}
-          {isMoreInfoActive ? (
-            <>
-              <span className="mosaic-work-history-expanded-break" aria-hidden="true" />
-              {renderMoreInfoExpansion()}
-            </>
-          ) : null}
-          <button
-            type="button"
-            className="mosaic-work-history-chip mosaic-work-history-chip-more"
-            aria-expanded={isMoreInfoActive}
-            aria-controls={isMoreInfoActive ? `${disclosureId}-more-info-expanded` : undefined}
-            onClick={() => toggleCompany(moreInfoId)}
-          >
-            ...
-          </button>
+          {profileCompanies.previousCompanies.map((company) => (
+            <WorkHistoryTrigger
+              key={company.id}
+              active={activeCompanyId === company.id}
+              company={company}
+              descriptionId={`${popoverId}-${company.id}-description`}
+              popoverId={popoverId}
+              onBlur={handleFocusLeave}
+              onClick={handleTriggerClick}
+              onFocus={handleTriggerFocus}
+              onPointerDown={(companyId) => {
+                pointerFocusCompanyIdRef.current = companyId
+              }}
+              onPointerEnter={handleTriggerPointerEnter}
+              onPointerLeave={handleTriggerPointerLeave}
+              onPointerMove={handleTriggerPointerMove}
+              setTrigger={setTrigger}
+            />
+          ))}
         </div>
+
+        <div
+          ref={popoverRef}
+          id={popoverId}
+          role="dialog"
+          aria-label={activeCompany ? `${activeCompany.name}, ${activeCompany.role}` : "Work history details"}
+          aria-hidden={activeCompany ? undefined : true}
+          className="mosaic-work-history-popover"
+          data-open={activeCompany ? "true" : "false"}
+          data-switching={isSwitchingCompany ? "true" : "false"}
+          data-side={position.side}
+          style={popoverStyle}
+          onFocus={() => clearCloseTimeout()}
+          onBlur={handleFocusLeave}
+          onPointerEnter={() => {
+            clearCloseTimeout()
+            // Reading the panel should not fight the lean it arrived with.
+            settleTilt()
+          }}
+          onPointerLeave={(event) => {
+            if (!isHoverCapable()) return
+            const destination = event.relatedTarget
+            if (destination instanceof Node && containerRef.current?.contains(destination)) return
+            scheduleClose()
+          }}
+        >
+          <span className="mosaic-work-history-popover-arrow" aria-hidden="true" />
+          {activeCompany ? (
+            <div key={activeCompany.id} className="mosaic-work-history-popover-content">
+              <div className="mosaic-work-history-popover-heading">
+                <span className="mosaic-work-history-popover-logos" aria-hidden="true">
+                  {activeCompany.logoUrls.map((logoUrl) => (
+                    <span key={`${activeCompany.id}-${logoUrl}`} className="mosaic-work-history-popover-logo-wrap">
+                      <img src={logoUrl} alt="" loading="eager" decoding="async" />
+                    </span>
+                  ))}
+                </span>
+                <span className="mosaic-work-history-popover-title">
+                  <span className="mosaic-work-history-popover-name">{activeCompany.name}</span>
+                  <span className="mosaic-work-history-popover-role">{activeCompany.role}</span>
+                </span>
+              </div>
+              <p className="mosaic-work-history-popover-description">{activeCompany.description}</p>
+              <a
+                href={activeCompany.href}
+                target="_blank"
+                rel="noreferrer"
+                className="mosaic-work-history-popover-link"
+                aria-label={`Visit ${new URL(activeCompany.href).hostname.replace(/^www\./, "")}`}
+              >
+                {new URL(activeCompany.href).hostname.replace(/^www\./, "")}
+                <span aria-hidden="true">›</span>
+              </a>
+            </div>
+          ) : null}
+        </div>
+
+        <span className="sr-only">
+          {[profileCompanies.recentGroup, ...profileCompanies.previousCompanies].flatMap((company) =>
+            company ? (
+              <span key={company.id} id={`${popoverId}-${company.id}-description`}>
+                {company.role}. {company.description}
+              </span>
+            ) : [],
+          )}
+        </span>
       </div>
     )
   }

--- a/src/index.css
+++ b/src/index.css
@@ -1495,6 +1495,262 @@ img {
   }
 }
 
+.mosaic-work-history {
+  position: relative;
+  z-index: 40;
+  min-height: auto;
+  overflow: visible;
+  isolation: isolate;
+
+  /* Pointer-relative tilt, written by handleTriggerPointerMove. Declared here
+     rather than on the popover because the popover is a sibling of the
+     triggers and inherits these through the shared container. */
+  --mosaic-popover-anchor-x: 0px;
+  --mosaic-popover-anchor-y: 0px;
+  --mosaic-popover-tilt-x: 0deg;
+  --mosaic-popover-tilt-y: 0deg;
+  --mosaic-popover-lift: 1;
+}
+
+.mosaic-work-history-popover {
+  --mosaic-popover-width: min(24rem, calc(100vw - 2rem));
+  position: absolute;
+  top: var(--mosaic-popover-y);
+  left: var(--mosaic-popover-x);
+  z-index: 4;
+  width: var(--mosaic-popover-width);
+  padding: 0.625rem 0.75rem;
+  border-radius: 16px;
+  background: #ffffff;
+  text-align: left;
+  box-shadow:
+    0 0 0 1px rgb(0 0 0 / 0.06),
+    0 1px 2px -1px rgb(0 0 0 / 0.06),
+    0 8px 24px -8px rgb(0 0 0 / 0.12);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+
+  /* Centring lives in the transform shorthand alongside the tilt. Using the
+     `translate:` longhand here instead would leave the lean on a separate
+     animation channel from the anchor slide, and the two would drift apart. */
+  transform:
+    perspective(1200px)
+    translate(calc(-50% + var(--mosaic-popover-anchor-x)), calc(-100% + var(--mosaic-popover-anchor-y)))
+    rotateX(var(--mosaic-popover-tilt-x))
+    rotateY(var(--mosaic-popover-tilt-y))
+    scale(var(--mosaic-popover-lift));
+  /* Hinge on the arrow edge, so the panel leans away from the word it points
+     at and the arrow stays pinned instead of swinging. */
+  transform-origin: center bottom;
+  transform-style: preserve-3d;
+  will-change: transform;
+  transition:
+    top 140ms cubic-bezier(0.16, 1, 0.3, 1),
+    left 140ms cubic-bezier(0.16, 1, 0.3, 1),
+    transform 140ms cubic-bezier(0.16, 1, 0.3, 1),
+    opacity 100ms ease,
+    visibility 100ms ease;
+}
+
+.mosaic-work-history-popover[data-side="below"] {
+  transform:
+    perspective(1200px)
+    translate(calc(-50% + var(--mosaic-popover-anchor-x)), var(--mosaic-popover-anchor-y))
+    rotateX(var(--mosaic-popover-tilt-x))
+    rotateY(var(--mosaic-popover-tilt-y))
+    scale(var(--mosaic-popover-lift));
+  transform-origin: center top;
+}
+
+.mosaic-work-history-popover[data-open="true"] {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition:
+    top 140ms cubic-bezier(0.16, 1, 0.3, 1),
+    left 140ms cubic-bezier(0.16, 1, 0.3, 1),
+    transform 140ms cubic-bezier(0.16, 1, 0.3, 1),
+    opacity 120ms cubic-bezier(0.16, 1, 0.3, 1),
+    visibility 120ms ease;
+}
+
+.mosaic-work-history-popover[data-switching="true"],
+.mosaic-work-history-popover[data-switching="true"] .mosaic-work-history-popover-arrow {
+  transition: none;
+}
+
+.mosaic-work-history-popover[data-switching="true"] .mosaic-work-history-popover-content {
+  animation: none;
+}
+
+.mosaic-work-history-popover-arrow {
+  position: absolute;
+  left: var(--mosaic-popover-arrow-x);
+  bottom: -5px;
+  width: 10px;
+  height: 10px;
+  margin-left: -5px;
+  border-radius: 3px;
+  background: #ffffff;
+  box-shadow: 2px 2px 0 rgb(0 0 0 / 0.06);
+  transform: rotate(45deg);
+  transition: left 140ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.mosaic-work-history-popover[data-side="below"] .mosaic-work-history-popover-arrow {
+  top: -5px;
+  bottom: auto;
+  border-radius: 3px;
+  box-shadow: -2px -2px 0 rgb(0 0 0 / 0.06);
+}
+
+.mosaic-work-history-popover-content {
+  animation: mosaic-work-history-popover-swap 120ms ease both;
+}
+
+.mosaic-work-history-popover-heading {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.4rem;
+  margin-bottom: 0.15rem;
+}
+
+.mosaic-work-history-popover-title {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: baseline;
+  column-gap: 0.35rem;
+}
+
+.mosaic-work-history-popover-name {
+  color: #171717;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  line-height: 1.5;
+  letter-spacing: -0.005rem;
+}
+
+.mosaic-work-history-popover-role {
+  color: #8a8a8a;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 1.5;
+}
+
+.mosaic-work-history-popover-role::before {
+  content: "·";
+  margin-right: 0.35rem;
+  color: #b5b5b5;
+}
+
+.mosaic-work-history-popover-description {
+  margin: 0;
+  color: #6f6f6f;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+  letter-spacing: -0.005rem;
+  text-wrap: pretty;
+}
+
+.mosaic-work-history-popover-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  margin-top: 0.4rem;
+  padding: 0.1rem 0.35rem;
+  border-radius: 6px;
+  background: #f2f2f2;
+  color: #6f6f6f;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  text-decoration: none;
+  transition:
+    background-color 160ms ease,
+    color 160ms ease;
+}
+
+.mosaic-work-history-popover-link:hover {
+  background: #e9e9e9;
+  color: #171717;
+}
+
+.mosaic-work-history-popover-link:focus-visible {
+  outline: 2px solid #9ea6b5;
+  outline-offset: 2px;
+}
+
+.mosaic-work-history-popover-logos {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+}
+
+.mosaic-work-history-popover-logo-wrap {
+  display: inline-flex;
+  width: 1.35rem;
+  height: 1.35rem;
+  align-items: center;
+  justify-content: center;
+  padding: 0.29rem;
+  border-radius: 999px;
+  background: #ffffff;
+  box-shadow: inset 0 0 0 1px rgb(0 0 0 / 0.05);
+}
+
+.mosaic-work-history-popover-logo-wrap + .mosaic-work-history-popover-logo-wrap {
+  margin-left: -0.26rem;
+}
+
+.mosaic-work-history-popover-logo-wrap img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+@keyframes mosaic-work-history-popover-swap {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mosaic-work-history-popover,
+  .mosaic-work-history-popover[data-open="true"],
+  .mosaic-work-history-popover-arrow {
+    transition-duration: 80ms;
+  }
+
+  .mosaic-work-history-popover {
+    transform: translate(-50%, -100%);
+  }
+
+  .mosaic-work-history-popover[data-side="below"] {
+    transform: translate(-50%, 0);
+  }
+
+  .mosaic-work-history-popover,
+  .mosaic-work-history-popover-content {
+    animation: none;
+    filter: none;
+  }
+
+  .mosaic-work-history-popover-content {
+    transform: none;
+  }
+}
+
+@media (max-width: 520px) {
+  .mosaic-work-history-popover-arrow {
+    display: none;
+  }
+}
+
 .mosaic-company-inline-list {
   display: inline;
 }

--- a/src/lib/pointerTilt.ts
+++ b/src/lib/pointerTilt.ts
@@ -1,0 +1,122 @@
+/**
+ * Pointer-relative tilt for floating hover surfaces.
+ *
+ * Normalizes the pointer to -0.5…+0.5 within a reference box, then writes the
+ * result as CSS custom properties so the tilt stays in the compositor. Panels
+ * lean toward whichever edge of the word the cursor is nearest: right of centre
+ * tilts right, left of centre tilts left.
+ *
+ * The reference box and the element carrying the variables are separate on
+ * purpose — a popover anchored as a sibling of its trigger needs the pointer
+ * measured against the trigger but the variables set on a shared ancestor.
+ */
+
+/**
+ * Each value is the full edge-to-edge sweep, so hovering either edge yields
+ * half of it: `tiltY: 8` leans ±4deg.
+ */
+export type PointerTiltScales = {
+  /** Horizontal slide toward the cursor, in px. */
+  anchorX: number
+  /** Vertical slide toward the cursor, in px. */
+  anchorY: number
+  /** rotateX in degrees. Applied inverted, so the edge nearest the cursor dips. */
+  tiltX: number
+  /** rotateY in degrees. This is the left/right lean. */
+  tiltY: number
+  /** Extra scale as a fraction: 0.01 grows up to 0.5% at an edge. */
+  lift: number
+}
+
+/** The original inline-logo-chip feel, kept as the default. */
+export const logoChipTilt: PointerTiltScales = {
+  anchorX: 12,
+  anchorY: 4,
+  tiltX: 4,
+  tiltY: 8,
+  lift: 0.01,
+}
+
+/** Half-strength values for elements nested inside a surface that already tilts. */
+export const nestedChipTilt: PointerTiltScales = {
+  anchorX: 12,
+  anchorY: 4,
+  tiltX: 2,
+  tiltY: 4,
+  lift: 0.006,
+}
+
+/**
+ * Gentler values for the work-history popover. It is roughly ten times the
+ * width of a logo chip, so the chip's sweep reads as a slot machine rather
+ * than a lean. This lands at about ±1.75deg at the edges.
+ */
+export const popoverTilt: PointerTiltScales = {
+  anchorX: 6,
+  anchorY: 2,
+  tiltX: 1.5,
+  tiltY: 3.5,
+  lift: 0.004,
+}
+
+function prefersReducedMotion() {
+  return typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches
+}
+
+function names(prefix: string) {
+  return {
+    anchorX: `--${prefix}-anchor-x`,
+    anchorY: `--${prefix}-anchor-y`,
+    tiltX: `--${prefix}-tilt-x`,
+    tiltY: `--${prefix}-tilt-y`,
+    lift: `--${prefix}-lift`,
+  }
+}
+
+/**
+ * Measure `pointer` against `box` and write the tilt variables onto `target`.
+ *
+ * `prefix` picks the variable namespace, e.g. `mosaic-hover` writes
+ * `--mosaic-hover-tilt-y`.
+ */
+export function applyPointerTilt({
+  target,
+  box,
+  pointer,
+  scales,
+  prefix,
+}: {
+  target: HTMLElement
+  box: DOMRect
+  pointer: { clientX: number; clientY: number }
+  scales: PointerTiltScales
+  prefix: string
+}) {
+  // Inline styles outrank a stylesheet media query, so the reduced-motion
+  // opt-out has to happen here rather than in CSS.
+  if (prefersReducedMotion()) {
+    resetPointerTilt(target, prefix)
+    return
+  }
+
+  const relativeX = box.width === 0 ? 0 : (pointer.clientX - box.left) / box.width - 0.5
+  const relativeY = box.height === 0 ? 0 : (pointer.clientY - box.top) / box.height - 0.5
+  const property = names(prefix)
+
+  target.style.setProperty(property.anchorX, `${(relativeX * scales.anchorX).toFixed(2)}px`)
+  target.style.setProperty(property.anchorY, `${(relativeY * scales.anchorY).toFixed(2)}px`)
+  target.style.setProperty(property.tiltX, `${(-relativeY * scales.tiltX).toFixed(2)}deg`)
+  target.style.setProperty(property.tiltY, `${(relativeX * scales.tiltY).toFixed(2)}deg`)
+  target.style.setProperty(property.lift, `${(1 + Math.abs(relativeX) * scales.lift).toFixed(3)}`)
+}
+
+/** Return the tilt variables in `prefix` to their resting values. */
+export function resetPointerTilt(target: HTMLElement, prefix: string) {
+  const property = names(prefix)
+
+  target.style.setProperty(property.anchorX, "0px")
+  target.style.setProperty(property.anchorY, "0px")
+  target.style.setProperty(property.tiltX, "0deg")
+  target.style.setProperty(property.tiltY, "0deg")
+  target.style.setProperty(property.lift, "1")
+}

--- a/tests/e2e/portfolio-polish.spec.ts
+++ b/tests/e2e/portfolio-polish.spec.ts
@@ -153,20 +153,124 @@ test("keeps desktop gallery navigation fixed near the modal top", async ({ page 
   await expect(dialog.locator(".preview-gallery-count")).toHaveText("2 / 12")
 })
 
-test("keeps a semantic disclosure control while work-history details are expanded", async ({ page }) => {
+test("travels one role-bearing work-history popover between company triggers without shifting the page", async ({ page }) => {
   await page.goto("/")
-  const disclosure = page.getByRole("button", { name: "0x.org and Matcha.xyz" })
-  await disclosure.click()
+  const location = page.locator(".mosaic-profile-location")
+  await location.evaluate((element) => Promise.all(element.getAnimations().map((animation) => animation.finished)))
+  const initialLocationBox = await location.boundingBox()
+  const popover = page.locator(".mosaic-work-history-popover")
+  const onit = page.getByRole("button", { name: "Onit" })
 
-  const expandedControl = page.getByRole("button", { name: "Collapse 0x.org and Matcha.xyz details" })
-  await expect(expandedControl).toHaveAttribute("aria-expanded", "true")
-  const controlledId = await expandedControl.getAttribute("aria-controls")
-  expect(controlledId).toBeTruthy()
-  await expect(page.locator(`#${controlledId}`)).toBeVisible()
+  await onit.hover()
+  await expect(popover).toBeVisible()
+  await expect(popover.locator(".mosaic-work-history-popover-name")).toHaveText("Onit")
+  await expect(popover.locator(".mosaic-work-history-popover-role")).toHaveText("Frontend dev and designer")
+  const visitLink = popover.getByRole("link", { name: "Visit onit.com" })
+  await expect(visitLink).toBeVisible()
+  await expect(popover).toHaveCSS("text-align", "left")
+  await expect(visitLink).toHaveCSS("background-color", "rgb(242, 242, 242)")
+  await expect(page.locator(".mosaic-work-history")).toHaveCSS("z-index", "40")
+  await expect(popover).toHaveAttribute("data-side", "above")
+  await expect(popover.locator(".mosaic-work-history-popover-arrow")).toHaveCSS("border-radius", "3px")
+  const longestPopoverTransition = await popover.evaluate((element) =>
+    Math.max(
+      ...getComputedStyle(element)
+        .transitionDuration.split(",")
+        .map((duration) => Number.parseFloat(duration) * (duration.includes("ms") ? 0.001 : 1)),
+    ),
+  )
+  expect(longestPopoverTransition).toBeLessThanOrEqual(0.14)
 
-  await expandedControl.focus()
-  await expandedControl.press("Enter")
-  await expect(page.getByRole("button", { name: "0x.org and Matcha.xyz" })).toBeVisible()
+  const onitPopoverBox = await popover.boundingBox()
+  const onitLocationBox = await location.boundingBox()
+  expect(initialLocationBox).not.toBeNull()
+  expect(onitPopoverBox).not.toBeNull()
+  expect(onitLocationBox!.y).toBeCloseTo(initialLocationBox!.y, 0)
+
+  await page.getByRole("button", { name: "Moody's" }).hover()
+  await expect(popover.locator(".mosaic-work-history-popover-name")).toHaveText("Moody's")
+  await expect(popover.locator(".mosaic-work-history-popover-role")).toHaveText("Frontend dev and designer")
+  expect(
+    await popover.evaluate(
+      (element) => element.getAnimations({ subtree: true }).filter((animation) => animation.playState !== "finished").length,
+    ),
+  ).toBe(0)
+  expect((await page.locator(".mosaic-work-history-popover").count())).toBe(1)
+  expect((await popover.boundingBox())!.x).not.toBe(onitPopoverBox!.x)
+  expect((await location.boundingBox())!.y).toBeCloseTo(initialLocationBox!.y, 0)
+
+  await page.getByRole("button", { name: "0x.org and Matcha.xyz" }).hover()
+  await expect(popover.locator(".mosaic-work-history-popover-name")).toHaveText("0x.org and Matcha.xyz")
+
+  await page.getByRole("button", { name: "Google" }).hover()
+  await expect(popover.locator(".mosaic-work-history-popover-name")).toHaveText("Google")
+  await expect(popover.locator(".mosaic-work-history-popover-role")).toHaveText("Design collab")
+
+  await page.getByRole("button", { name: "Protector and Patrol" }).hover()
+  await expect(popover.locator(".mosaic-work-history-popover-name")).toHaveText("Protector and Patrol")
+  await expect(popover.locator(".mosaic-work-history-popover-role")).toHaveText("Design collab")
+})
+
+test("opens the work-history popover from the keyboard and toggles it on touch", async ({ page }) => {
+  await page.goto("/")
+  const onit = page.getByRole("button", { name: "Onit" })
+  const popover = page.locator(".mosaic-work-history-popover")
+
+  await onit.focus()
+  await expect(popover).toBeVisible()
+  await page.keyboard.press("Escape")
+  await expect(popover).toBeHidden()
+  await expect(onit).toBeFocused()
+
+  await page.setViewportSize(mobileViewport)
+  await page.goto("/")
+  const mobileOnit = page.getByRole("button", { name: "Onit" })
+  const mobilePopover = page.locator(".mosaic-work-history-popover")
+  await mobileOnit.click()
+  await expect(mobilePopover).toBeVisible()
+  await mobileOnit.click()
+  await expect(mobilePopover).toBeHidden()
+})
+
+test("keeps the work-history popover positioned with reduced motion", async ({ page }) => {
+  await page.setViewportSize(mobileViewport)
+  await page.emulateMedia({ reducedMotion: "reduce" })
+  await page.goto("/")
+
+  const onit = page.getByRole("button", { name: "Onit" })
+  const popover = page.locator(".mosaic-work-history-popover")
+  await onit.focus()
+  await expect(popover).toBeVisible()
+
+  const triggerBox = await onit.boundingBox()
+  const popoverBox = await popover.boundingBox()
+  expect(triggerBox).not.toBeNull()
+  expect(popoverBox).not.toBeNull()
+  expect(popoverBox!.x).toBeGreaterThanOrEqual(0)
+  expect(popoverBox!.x + popoverBox!.width).toBeLessThanOrEqual(mobileViewport.width)
+  expect(popoverBox!.y + popoverBox!.height).toBeLessThanOrEqual(triggerBox!.y)
+})
+
+test("moves the work-history popover below its trigger near the viewport top", async ({ page }) => {
+  await page.setViewportSize(mobileViewport)
+  await page.goto("/")
+
+  const onit = page.getByRole("button", { name: "Onit" })
+  const popover = page.locator(".mosaic-work-history-popover")
+  await onit.focus()
+  await expect(popover).toBeVisible()
+  await expect(popover).toHaveAttribute("data-side", "above")
+
+  await page.evaluate(() => window.scrollBy(0, 180))
+  await expect(popover).toHaveAttribute("data-side", "below")
+  await popover.evaluate((element) => Promise.all(element.getAnimations().map((animation) => animation.finished)))
+
+  const triggerBox = await onit.boundingBox()
+  const popoverBox = await popover.boundingBox()
+  expect(triggerBox).not.toBeNull()
+  expect(popoverBox).not.toBeNull()
+  expect(popoverBox!.y).toBeGreaterThanOrEqual(triggerBox!.y + triggerBox!.height)
+  expect(popoverBox!.y + popoverBox!.height).toBeLessThanOrEqual(mobileViewport.height)
 })
 
 test("shows project captions and contains Protector artwork on touch layouts", async ({ page }) => {


### PR DESCRIPTION
## Summary

Replaces inline work-history expansions with a single accessible popover that supports hover, keyboard focus, touch toggling, outside-click dismissal, and Escape focus restoration.
Extracts shared pointer-relative tilt behavior for logo chips and the new popover, with reduced-motion handling.
Keeps the popover inside the viewport by switching above or below its trigger and recalculating on scroll or resize; this also fixes positioning that previously broke when reduced motion removed the transform.

## Validation

- `npm run lint`
- `npm run build`
- `npx playwright test tests/e2e/portfolio-polish.spec.ts --grep 'work-history'`
