### PR TITLE
Stagger work cards on initial page load

### DIFF
--- a/src/components/SimpleFeed.tsx
+++ b/src/components/SimpleFeed.tsx
@@ -343,10 +343,14 @@ export function SimpleFeed({ cards, profile, links, showProjects = true }: Simpl
   )
   const [view, setView] = useState<"work" | "about">("work")
   const [isSwapping, setIsSwapping] = useState(false)
-  // The swap animation is for swaps only. On first paint the work rows are
-  // already there, and animating them would fight the hero intro and leave the
-  // mosaic mid-scale for anything measuring it.
+  // Two entrance systems share the mosaic, and `hasSwapped` picks between them:
+  // before the first swap the rows carry `.mosaic-work-intro` (the CSS-only
+  // first-load cascade, which has to be in the prerendered HTML), after it they
+  // carry `.mosaic-view-animated` (the swap stagger). Never both -- the swap
+  // animation scales the container, which would leave the mosaic mid-scale for
+  // anything measuring it if it also ran on load.
   const [hasSwapped, setHasSwapped] = useState(false)
+  const [hasCompletedWorkIntro, setHasCompletedWorkIntro] = useState(false)
   const swapTimeoutRef = useRef<number | null>(null)
   const avatarRef = useRef<HTMLButtonElement | null>(null)
   const viewTriggerRef = useRef<HTMLElement | null>(null)
@@ -452,7 +456,12 @@ export function SimpleFeed({ cards, profile, links, showProjects = true }: Simpl
     if (typeof window === "undefined" || typeof window.matchMedia !== "function") return
 
     const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)")
-    const syncPreference = () => setPrefersReducedMotion(mediaQuery.matches)
+    const syncPreference = () => {
+      setPrefersReducedMotion(mediaQuery.matches)
+      // Reduced motion suppresses animationend, so retire the one-shot marker
+      // here before a later preference change can start the intro mid-session.
+      if (mediaQuery.matches) setHasCompletedWorkIntro(true)
+    }
     syncPreference()
 
     if (typeof mediaQuery.addEventListener === "function") {
@@ -640,7 +649,15 @@ export function SimpleFeed({ cards, profile, links, showProjects = true }: Simpl
           ) : (
             <article id="work" className="mosaic-work">
               <h2 className="sr-only">Selected work</h2>
-              <div className="mosaic-rows" aria-label="Selected work previews">
+              {/* No `prefersReducedMotion` here on purpose: it is false on the
+                  server and on the first client render, so a JS gate would flash
+                  before the effect syncs. Reduced motion is handled in CSS. */}
+              <div
+                className={`mosaic-rows${
+                  hasSwapped || hasCompletedWorkIntro ? "" : " mosaic-work-intro"
+                }`}
+                aria-label="Selected work previews"
+              >
                 {rowsRender.map((row, rowIndex) => {
                   const rowStyle = {
                     ...(row.height ? { "--row-height": row.height } : {}),
@@ -649,7 +666,7 @@ export function SimpleFeed({ cards, profile, links, showProjects = true }: Simpl
                   const eagerRow = rowIndex === 0
                   return (
                     <div key={row.id} className="mosaic-row" style={rowStyle}>
-                      {row.items.map((item) => {
+                      {row.items.map((item, itemIndex) => {
                         const itemKey = `${item.card.id}-${item.previewIndex}`
                         const paginationTotal = getPaginationTotal(item.card)
                         const isPaginatedCard = paginationTotal > 1
@@ -662,6 +679,10 @@ export function SimpleFeed({ cards, profile, links, showProjects = true }: Simpl
                           : item.card.title
                         const itemStyle = {
                           "--row-span": item.span,
+                          // Feeds the first-load stagger in `.mosaic-work-intro`.
+                          // Inert without that class, so set unconditionally.
+                          "--work-intro-row": rowIndex,
+                          "--work-intro-col": itemIndex,
                           ...(item.width ? { flex: `0 0 ${item.width}` } : {}),
                           ...(item.mediaMaxHeight ? { "--row-media-max-height": item.mediaMaxHeight } : {}),
                         } as CSSProperties
@@ -670,6 +691,16 @@ export function SimpleFeed({ cards, profile, links, showProjects = true }: Simpl
                             key={itemKey}
                             className={`mosaic-row-item mosaic-row-item-fit-${item.fit}`}
                             style={itemStyle}
+                            onAnimationEnd={
+                              rowIndex === rowsRender.length - 1 &&
+                              itemIndex === row.items.length - 1
+                                ? (event) => {
+                                    if (event.target === event.currentTarget) {
+                                      setHasCompletedWorkIntro(true)
+                                    }
+                                  }
+                                : undefined
+                            }
                           >
                             <button
                               type="button"

--- a/src/index.css
+++ b/src/index.css
@@ -872,6 +872,58 @@ img {
   }
 }
 
+/* First-load entrance for the work cards. Unlike the swap stagger above, this
+   one has to exist in the prerendered HTML: CSS animations start at first paint,
+   long before hydration, so the class comes from `!hasSwapped` in SimpleFeed
+   rather than from an effect. `hasSwapped` drops the class on the first view
+   swap, handing the mosaic over to `.mosaic-view-animated` above -- the two
+   never overlap. Delays are data-driven from inline `--work-intro-row` and
+   `--work-intro-col` rather than nth-child, so all twelve cards stagger; the
+   swap rule above silently stops at nth-child(4).
+   Keep `--work-intro-row-step` at or above 2 x `--work-intro-col-step`. Below
+   700px the rows collapse into one flex column, and a smaller row step would
+   make a card arrive before the card above it. */
+.mosaic-work-intro {
+  --work-intro-base: 320ms;
+  --work-intro-row-step: 90ms;
+  --work-intro-col-step: 40ms;
+}
+
+/* opacity and translateY only. A scale would change the measured box of
+   `.mosaic-row`, whose height is asserted at exactly 420px in
+   tests/e2e/portfolio-polish.spec.ts. The 0.8rem travel matches the hero's and
+   stays under the 1rem row gap, so a rising card never covers the one below. */
+.mosaic-work-intro .mosaic-row-item {
+  animation: mosaic-intro-rise 540ms var(--ease-smooth) both;
+  animation-delay: calc(
+    var(--work-intro-base) +
+    var(--work-intro-row, 0) * var(--work-intro-row-step) +
+    var(--work-intro-col, 0) * var(--work-intro-col-step)
+  );
+}
+
+/* The top row carries the LCP element (the largest poster), and wrapping that
+   element in an opacity animation defers its recorded paint by ~300ms no matter
+   how short the delay is -- measured at Fast 3G + 4x CPU, LCP is ~384ms with no
+   entrance and ~696ms once the row-0 item fades, and shortening
+   `--work-intro-base` makes it no better. So the top row rises without fading.
+   Nothing is lost: `.mosaic-row-media` already owns a fade through its blur-up,
+   so the card still reads as arriving, and LCP measures ~376ms -- back at
+   baseline. Keep this row transform-only. */
+@keyframes mosaic-intro-lift {
+  from {
+    transform: translateY(0.8rem);
+  }
+
+  to {
+    transform: translateY(0);
+  }
+}
+
+.mosaic-work-intro .mosaic-row:first-child .mosaic-row-item {
+  animation-name: mosaic-intro-lift;
+}
+
 .mosaic-about {
   display: block;
   padding: 0 clamp(16px, 3vw, 32px) clamp(3rem, 8vw, 5rem);
@@ -3173,10 +3225,17 @@ img {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .mosaic-row-item {
-    opacity: 1;
-    transform: none;
-    transition: none;
+  /* The global reduced-motion reset at the bottom of this file zeroes
+     animation-duration but not animation-delay, so a delayed `both`-filled
+     entrance still holds its from-state -- invisible -- for the whole delay
+     window. These selectors have to match or beat the specificity of the rules
+     that set the animation, or those win despite coming earlier -- the row-0
+     override in particular sets `animation-name` at a higher specificity than a
+     bare `.mosaic-row-item` reset could reach. */
+  .mosaic-work-intro .mosaic-row-item,
+  .mosaic-work-intro .mosaic-row:first-child .mosaic-row-item,
+  .mosaic-hero-profile-animated > * {
+    animation: none;
   }
 
   .mosaic-row-card-paginated .mosaic-row-media,

--- a/tests/e2e/portfolio-polish.spec.ts
+++ b/tests/e2e/portfolio-polish.spec.ts
@@ -1,6 +1,17 @@
-import { expect, test } from "@playwright/test"
+import { expect, type Page, test } from "@playwright/test"
 
 const mobileViewport = { width: 390, height: 844 }
+
+// The work cards cascade in on first load, so a card clicked straight after
+// `goto` can still be sitting at its pre-start offset -- and the gallery grows
+// out of that card's live rect. Settle the cascade before touching a card.
+// Safe from hanging: nothing in index.css animates infinitely.
+const settleWorkCards = (page: Page) =>
+  page
+    .locator(".mosaic-rows")
+    .evaluate((element) =>
+      Promise.all(element.getAnimations({ subtree: true }).map((animation) => animation.finished)),
+    )
 
 test("hydrates the prerendered portfolio without browser errors", async ({ page, request }) => {
   const errors: string[] = []
@@ -38,6 +49,7 @@ test("operates the profile name disclosure from the keyboard and restores focus"
 test("keeps gallery controls inside the mobile viewport and exposes a close button", async ({ page }) => {
   await page.setViewportSize(mobileViewport)
   await page.goto("/")
+  await settleWorkCards(page)
   await page.getByRole("button", { name: /Open Matcha - Multiwallet flow/ }).click()
 
   const dialog = page.getByRole("dialog")
@@ -96,6 +108,7 @@ test("keeps gallery controls inside the mobile viewport and exposes a close butt
 
 test("returns focus to the originating project after closing the gallery", async ({ page }) => {
   await page.goto("/")
+  await settleWorkCards(page)
   const trigger = page.getByRole("button", { name: /Open Matcha - Multiwallet flow/ })
   await trigger.focus()
   await trigger.press("Enter")
@@ -118,6 +131,7 @@ test("opens the gallery after an intent prefetch fails", async ({ page }) => {
     releaseFailedPrefetch?.()
   })
   await page.goto("/")
+  await settleWorkCards(page)
 
   const trigger = page.getByRole("button", { name: /Open Matcha - Mobile Screens preview/ })
   await trigger.hover()
@@ -261,4 +275,118 @@ test("constrains the desktop mosaic at wide viewport sizes", async ({ page }) =>
   expect(firstRow).not.toBeNull()
   // Rows are a flat 420px from the 900px breakpoint up (see .mosaic-row in index.css).
   expect(firstRow!.height).toBe(420)
+})
+
+// The first-load card cascade is CSS driven off a class and two custom
+// properties in the prerendered HTML, because animations start at first paint
+// long before hydration. Moving any of it into an effect breaks this test.
+test("ships the work-card intro in the prerendered markup", async ({ request }) => {
+  const html = await (await request.get("/")).text()
+  expect(html).toContain("mosaic-work-intro")
+  expect(html).toContain("--work-intro-row:3")
+  expect(html).toContain("--work-intro-col:2")
+})
+
+test("keeps the work-card entrance free of scale and horizontal travel", async ({ page }) => {
+  await page.goto("/")
+
+  // Read the keyframe source rather than a live animation: the mosaic row height
+  // is asserted at exactly 420px above, and only opacity plus translateY leave
+  // that measurement alone.
+  const keyframes = await page.evaluate(() => {
+    const wanted = ["mosaic-intro-rise", "mosaic-intro-lift"]
+    const found: Record<string, string[]> = {}
+    for (const sheet of [...document.styleSheets]) {
+      for (const rule of [...sheet.cssRules]) {
+        if (rule instanceof CSSKeyframesRule && wanted.includes(rule.name)) {
+          found[rule.name] = [...rule.cssRules].map((frame) => (frame as CSSKeyframeRule).style.transform)
+        }
+      }
+    }
+    return found
+  })
+
+  expect(Object.keys(keyframes).sort()).toEqual(["mosaic-intro-lift", "mosaic-intro-rise"])
+  for (const transforms of Object.values(keyframes)) {
+    for (const transform of transforms) {
+      expect(transform === "" || /^translateY\([^)]+\)$/.test(transform)).toBe(true)
+    }
+  }
+})
+
+// The top row holds the LCP element. Fading it defers the recorded paint by
+// ~300ms regardless of the delay, so that row rises without animating its own
+// opacity and lets the media blur-up own the fade. See index.css.
+test("keeps the top row of work cards out of the opacity entrance", async ({ page }) => {
+  await page.goto("/")
+
+  const rows = await page.evaluate(() =>
+    [...document.querySelectorAll(".mosaic-row")].map((row) => ({
+      names: [
+        ...new Set(
+          [...row.querySelectorAll(".mosaic-row-item")].map((el) => getComputedStyle(el).animationName),
+        ),
+      ],
+    })),
+  )
+
+  expect(rows.length).toBeGreaterThan(1)
+  expect(rows[0].names).toEqual(["mosaic-intro-lift"])
+  for (const row of rows.slice(1)) {
+    expect(row.names).toEqual(["mosaic-intro-rise"])
+  }
+})
+
+test("does not delay content behind an entrance under reduced motion", async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: "reduce" })
+  await page.goto("/")
+
+  // A one-shot read on purpose. The global reduced-motion reset zeroes
+  // animation-duration but not animation-delay, so a delayed `both`-filled
+  // entrance stays invisible for its whole delay -- and toHaveCSS would retry
+  // right past that window.
+  for (const selector of [".mosaic-row-item", ".mosaic-hero-profile-animated > *"]) {
+    const state = await page
+      .locator(selector)
+      .first()
+      .evaluate((element) => {
+        const style = getComputedStyle(element)
+        return { animationName: style.animationName, opacity: style.opacity }
+      })
+    expect(state.animationName).toBe("none")
+    expect(state.opacity).toBe("1")
+  }
+})
+
+test("does not replay the work-card intro when reduced motion is disabled later", async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: "reduce" })
+  await page.goto("/")
+
+  const rows = page.locator(".mosaic-rows")
+  await expect(rows).not.toHaveClass(/mosaic-work-intro/)
+
+  await page.emulateMedia({ reducedMotion: "no-preference" })
+  const states = await page.locator(".mosaic-row-item").evaluateAll((items) =>
+    items.map((item) => {
+      const style = getComputedStyle(item)
+      return { animationName: style.animationName, opacity: style.opacity }
+    }),
+  )
+
+  expect(states.every(({ animationName, opacity }) => animationName === "none" && opacity === "1")).toBe(true)
+})
+
+test("keeps the work-card entrance inside its delay budget", async ({ page }) => {
+  await page.goto("/")
+
+  const maxDelay = await page.evaluate(() =>
+    Math.max(
+      ...[...document.querySelectorAll(".mosaic-row-item")].map((element) =>
+        parseFloat(getComputedStyle(element).animationDelay),
+      ),
+    ),
+  )
+  // Last card starts at 320ms + 3 x 90ms + 2 x 40ms = 670ms. The ceiling is
+  // deliberately loose -- it guards against a runaway intro, not the exact base.
+  expect(maxDelay).toBeLessThanOrEqual(0.7)
 })


### PR DESCRIPTION
## Summary
- Add a prerendered staggered entrance for work cards while keeping the LCP-heavy first row transform-only.
- Respect reduced-motion preferences, retire the intro after its one-shot run, and prevent it from replaying when preferences change.
- Expand Playwright coverage for timing, transforms, prerendered markup, reduced motion, and gallery interactions.

## Testing
- `npm run lint`
- `npm run build`
- `npx playwright test tests/e2e/portfolio-polish.spec.ts` (21 passed)