### PR TITLE
Hide autoplay video controls in gallery previews

### DIFF
--- a/src/components/PreviewGalleryDialog.tsx
+++ b/src/components/PreviewGalleryDialog.tsx
@@ -530,7 +530,7 @@ export function PreviewGalleryDialog({
                         autoPlay={!prefersReducedMotion}
                         playsInline
                         preload={prefersReducedMotion ? "none" : "metadata"}
-                        controls
+                        controls={prefersReducedMotion}
                         aria-label={activeCard.title}
                         className="preview-gallery-media"
                       />

--- a/tests/e2e/portfolio-polish.spec.ts
+++ b/tests/e2e/portfolio-polish.spec.ts
@@ -329,6 +329,11 @@ test("renders intrinsic media dimensions and does not autoplay under reduced mot
   const video = page.locator(".mosaic-row-card video.mosaic-row-media").first()
   await expect(video).toHaveAttribute("poster", /\S+/)
   expect(await video.evaluate((element: HTMLVideoElement) => element.autoplay)).toBe(false)
+
+  await page.getByRole("button", { name: /Open Matcha - Multiwallet flow/ }).click()
+  const previewVideo = page.getByRole("dialog").locator("video")
+  expect(await previewVideo.evaluate((element: HTMLVideoElement) => element.autoplay)).toBe(false)
+  expect(await previewVideo.evaluate((element: HTMLVideoElement) => element.controls)).toBe(true)
 })
 
 test("loads video sources near the viewport and pauses them after they leave it", async ({ page }) => {


### PR DESCRIPTION
Removes native video controls from autoplaying gallery previews while retaining them when reduced motion disables autoplay. This keeps the default modal presentation clean without making paused previews inaccessible to reduced-motion users. Adds Playwright coverage for the reduced-motion gallery behavior.\n\nValidated with ESLint, the focused Playwright test, and git diff checks.