### PR TITLE
Add Rafael to project collaborations

### DIFF
--- a/src/components/PreviewGalleryDialog.tsx
+++ b/src/components/PreviewGalleryDialog.tsx
@@ -203,8 +203,22 @@ function getPreviewIndustry(card: PortfolioCard) {
 }
 
 function getPreviewCollaborators(card: PortfolioCard): Collaborator[] {
-  // Simon was the only other designer on the homepage and multiwallet work.
-  if (card.title.includes("Homepage") || card.title.includes("Multiwallet")) return [collaborators.simon]
+  const teammates = getPreviewTeammates(card)
+  // Credit myself alongside anyone I worked with; solo shots keep the Team row hidden.
+  return teammates.length > 0 ? [collaborators.rafael, ...teammates] : []
+}
+
+function getPreviewTeammates(card: PortfolioCard): Collaborator[] {
+  // Simon was the only other designer on the homepage, multiwallet, mobile nav and dark mode work.
+  if (
+    card.title.includes("Homepage") ||
+    card.title.includes("Multiwallet") ||
+    card.title.includes("Mobile navigation") ||
+    card.title.includes("Dark mode")
+  )
+    return [collaborators.simon]
+  // The token page and trade module were just Jakub and me.
+  if (card.title.includes("Token Page") || card.title.includes("Trade module")) return [collaborators.jakub]
   if (card.title.includes("Matcha")) return [collaborators.simon, collaborators.jakub]
   if (card.title.includes("Protector") || card.title.includes("Popparazi")) return [collaborators.nick]
   return []

--- a/src/data/portfolio.ts
+++ b/src/data/portfolio.ts
@@ -39,6 +39,8 @@ export type Collaborator = {
 }
 
 export const collaborators = {
+  // Listed first on every project so my own involvement reads at a glance.
+  rafael: { name: "Rafael Medina", href: "https://www.linkedin.com/in/rafaelmedian", photo: profilePhoto },
   nick: { name: "Nick Sarath", href: "https://www.linkedin.com/in/nicksarath", photo: "/people/nick.jpg" },
   simon: { name: "Simon Rico", href: "https://www.linkedin.com/in/simonrico/", photo: "/people/simon.jpg" },
   jakub: { name: "Jakub Antalik", href: "https://www.linkedin.com/in/jakubantalik/", photo: "/people/jakub.jpg" },


### PR DESCRIPTION
Adds Rafael Medina to project Team rows alongside collaborators, using the existing profile photo and LinkedIn link. Refines title-based teammate mappings so Simon and Jakub credits match the specific Matcha work while solo items continue to hide the Team row. Validation: `npm run lint`, `npm run build`, and the focused Playwright gallery test.