### PR TITLE
Animate the About tab toggle

### DIFF
--- a/src/components/AboutPanel.tsx
+++ b/src/components/AboutPanel.tsx
@@ -289,7 +289,13 @@ export function AboutPanel({ links }: AboutPanelProps) {
       <h2 className="sr-only">About Rafael Medina</h2>
       <div className="mosaic-about-panel">
         <div className="mosaic-about-body">
-          <div className="mosaic-about-tabs" role="tablist" aria-label="About me or resume">
+          <div
+            className="mosaic-about-tabs"
+            role="tablist"
+            aria-label="About me or resume"
+            data-active-tab={activeTab}
+          >
+            <span className="mosaic-about-tab-indicator" aria-hidden="true" />
             {aboutTabs.map((tab) => (
               <button
                 key={tab.id}

--- a/src/index.css
+++ b/src/index.css
@@ -721,13 +721,32 @@ img {
   top: clamp(1.1rem, 2.4vw, 1.5rem);
   left: 50%;
   transform: translateX(-50%);
-  display: inline-flex;
+  display: inline-grid;
+  grid-template-columns: repeat(2, 1fr);
   padding: 0.17rem;
   border-radius: 999px;
   background: rgb(0 0 0 / 0.06);
 }
 
+.mosaic-about-tab-indicator {
+  position: absolute;
+  inset-block: 0.17rem;
+  left: 0.17rem;
+  width: calc((100% - 0.34rem) / 2);
+  border-radius: 999px;
+  background: #ffffff;
+  box-shadow: 0 1px 4px rgb(46 42 42 / 0.14);
+  pointer-events: none;
+  transition: transform 240ms cubic-bezier(0.65, 0, 0.35, 1);
+}
+
+.mosaic-about-tabs[data-active-tab="resume"] .mosaic-about-tab-indicator {
+  transform: translateX(100%);
+}
+
 .mosaic-about-tab {
+  position: relative;
+  z-index: 1;
   appearance: none;
   border: 0;
   background: transparent;
@@ -742,10 +761,7 @@ img {
   text-wrap: nowrap;
   color: var(--muted);
   cursor: pointer;
-  transition:
-    color 160ms ease,
-    background-color 160ms ease,
-    box-shadow 160ms ease;
+  transition: color 160ms ease;
 }
 
 .mosaic-about-tab:hover {
@@ -753,9 +769,7 @@ img {
 }
 
 .mosaic-about-tab[aria-selected="true"] {
-  background: #ffffff;
   color: #2d2d2d;
-  box-shadow: 0 1px 4px rgb(46 42 42 / 0.14);
 }
 
 .mosaic-about-tabpanel {

--- a/tests/e2e/portfolio-polish.spec.ts
+++ b/tests/e2e/portfolio-polish.spec.ts
@@ -420,6 +420,23 @@ test("switches the about card between about me and resume", async ({ page }) => 
   await expect(panel).toContainText(/Hi, I.m Rafael/)
 })
 
+test("slides one shared selection pill between the about tabs", async ({ page }) => {
+  await page.goto("/")
+
+  const tabs = page.getByRole("tablist", { name: "About me or resume" })
+  const indicator = tabs.locator(".mosaic-about-tab-indicator")
+
+  await expect(indicator).toHaveCount(1)
+  const aboutPosition = await indicator.boundingBox()
+  expect(aboutPosition).not.toBeNull()
+
+  await tabs.getByRole("tab", { name: "resume" }).click()
+  await expect(tabs).toHaveAttribute("data-active-tab", "resume")
+  await expect
+    .poll(async () => (await indicator.boundingBox())?.x)
+    .toBeGreaterThan(aboutPosition?.x ?? 0)
+})
+
 test("lets keyboard users move and reset about stickers", async ({ page }) => {
   await page.setViewportSize({ width: 1000, height: 900 })
   await page.emulateMedia({ reducedMotion: "reduce" })


### PR DESCRIPTION
## Summary

Adds a shared white selection pill that slides between the About me and Resume tabs, replacing the two static selected backgrounds. The tabs now use equal-width segments so the indicator stays aligned, while the existing reduced-motion handling keeps the interaction accessible. Adds Playwright coverage that verifies the pill moves when the selected tab changes.

## Validation

`npm run lint`, `npm run build`, and `npm run test:e2e` (60 passed).
