### PR TITLE
Polish project card hover captions

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -116,33 +116,22 @@ body * {
 .mosaic-row-card-title {
   position: absolute;
   left: 50%;
-  bottom: clamp(0.78rem, 1.45vw, 1rem);
+  bottom: clamp(0.875rem, 1.4vw, 1.25rem);
   z-index: 2;
-  max-width: calc(100% - 2rem);
-  padding: 0.28rem 0.55rem;
-  border-radius: 999px;
-  background: rgb(0 0 0 / 0.58);
-  box-shadow:
-    0 1px 2px rgb(0 0 0 / 0.16),
-    0 8px 18px rgb(0 0 0 / 0.18);
-  -webkit-backdrop-filter: blur(8px);
-  backdrop-filter: blur(8px);
-  transform: translate(-50%, 0.38rem);
+  max-width: calc(100% - clamp(1.75rem, 2.8vw, 2.5rem));
+  transform: translate(-50%, 0.25rem);
   opacity: 0;
   pointer-events: none;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
   color: white;
-  font-size: 16px;
+  font-size: clamp(0.75rem, 1vw, 0.875rem);
   font-weight: 600;
-  line-height: 1.2;
-  letter-spacing: 0;
+  line-height: 1.12;
+  letter-spacing: -0.025em;
   text-align: center;
-  text-shadow: 0 1px 2px rgb(0 0 0 / 0.88);
+  text-shadow: 0 1px 8px rgb(0 0 0 / 0.28);
   transition:
-    opacity 180ms ease,
-    transform 220ms cubic-bezier(0.2, 0, 0, 1);
+    opacity 160ms ease-out,
+    transform 180ms cubic-bezier(0.2, 0, 0, 1);
 }
 
 .mosaic-row-card:hover .mosaic-row-card-title,
@@ -2327,6 +2316,29 @@ img {
     box-shadow 180ms ease;
 }
 
+.mosaic-row-card::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 0;
+  z-index: 1;
+  height: max(18%, 4.5rem);
+  pointer-events: none;
+  background: linear-gradient(
+    to top,
+    rgb(0 0 0 / 0.58) 0%,
+    rgb(0 0 0 / 0.38) 36%,
+    rgb(0 0 0 / 0.14) 68%,
+    transparent 100%
+  );
+  opacity: 0;
+  transition: opacity 160ms ease-out;
+}
+
+.mosaic-row-card:hover::after,
+.mosaic-row-card:focus-visible::after {
+  opacity: 1;
+}
+
 .mosaic-row-card:focus-visible {
   border-color: var(--focus-ring);
   background: #e9e9e9;
@@ -3442,6 +3454,10 @@ img {
   .mosaic-row-card-title {
     opacity: 1;
     transform: translate(-50%, 0);
+  }
+
+  .mosaic-row-card::after {
+    opacity: 1;
   }
 
   .mosaic-row-card-preview-protector .mosaic-row-media {

--- a/tests/e2e/portfolio-polish.spec.ts
+++ b/tests/e2e/portfolio-polish.spec.ts
@@ -1515,6 +1515,40 @@ test("shows project captions and contains Protector artwork on touch layouts", a
   await expect(protectorMedia).toHaveCSS("transform", "none")
 })
 
+test("keeps wrapped touch captions inside a bounded contrast gradient", async ({ browser }) => {
+  const context = await browser.newContext({
+    hasTouch: true,
+    isMobile: true,
+    viewport: { width: 768, height: 1024 },
+  })
+  const page = await context.newPage()
+
+  try {
+    await page.goto("/")
+
+    const caption = page.locator(".mosaic-row-card-title").first()
+    const layout = await caption.evaluate((element) => {
+      const card = element.closest<HTMLElement>(".mosaic-row-card")!
+      const cardBox = card.getBoundingClientRect()
+      const captionBox = element.getBoundingClientRect()
+      const gradient = getComputedStyle(card, "::after")
+
+      return {
+        cardHeight: cardBox.height,
+        captionHeight: captionBox.height,
+        captionTopFromBottom: cardBox.bottom - captionBox.top,
+        gradientHeight: Number.parseFloat(gradient.height),
+      }
+    })
+
+    expect(layout.captionHeight).toBeGreaterThan(20)
+    expect(layout.gradientHeight).toBeGreaterThanOrEqual(layout.captionTopFromBottom)
+    expect(layout.gradientHeight).toBeLessThan(layout.cardHeight / 2)
+  } finally {
+    await context.close()
+  }
+})
+
 test("renders intrinsic media dimensions and does not autoplay under reduced motion", async ({ page }) => {
   await page.emulateMedia({ reducedMotion: "reduce" })
   await page.goto("/")


### PR DESCRIPTION
Replaces the project-card title pill with a lighter text treatment and responsive bottom gradient for hover, keyboard focus, and touch layouts.

Keeps wrapped tablet captions inside the contrast gradient and adds a 768px touch regression test.

Tests: `npm run lint`, `npm run build`, and 97 Playwright tests.