### PR TITLE
Open portfolio previews wide on large desktops

### DIFF
--- a/src/components/DesignSystemPage.tsx
+++ b/src/components/DesignSystemPage.tsx
@@ -364,7 +364,10 @@ const BREAKPOINTS = [
   { at: "480–699.98px + fine hover", change: "Contact pills stay 32px tall and local time uses 14px type." },
   { at: "≥ 760px", change: "This page's own two-column grids. Not a portfolio breakpoint." },
   { at: "≥ 900px", change: "Mosaic rows go to 420px and the shell drops its inline padding." },
-  { at: "≥ 1320px", change: "The hero name settles at 16px." },
+  {
+    at: "≥ 1320px",
+    change: "The hero name settles at 16px; project previews open in the 1090px wide view with a 5vh top inset.",
+  },
 ]
 
 const STACKING = [

--- a/src/components/PreviewGalleryDialog.tsx
+++ b/src/components/PreviewGalleryDialog.tsx
@@ -21,6 +21,13 @@ type PreviewSwitchPhase = "idle" | "out" | "in"
 
 const previewSwitchExitMs = 190
 const previewCloseResetMs = 260
+const largeDesktopPreviewQuery = "(min-width: 1320px)"
+
+function shouldOpenPreviewWide() {
+  return typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia(largeDesktopPreviewQuery).matches
+}
 
 // Origin-aware open/close: the popup travels from (and back to) the card that
 // was clicked, so the modal reads as that card growing into place. Every
@@ -214,7 +221,7 @@ export function PreviewGalleryDialog({
   const [originWrapNode, setOriginWrapNode] = useState<HTMLDivElement | null>(null)
   const [switchPhase, setSwitchPhase] = useState<PreviewSwitchPhase>("idle")
   const [switchDirection, setSwitchDirection] = useState<PreviewSwitchDirection>("down")
-  const [isWide, setIsWide] = useState(false)
+  const [isWide, setIsWide] = useState(shouldOpenPreviewWide)
   const safeIndex = useMemo(() => wrapIndex(selectedIndex, cards.length), [cards.length, selectedIndex])
   const activeCard = cards[safeIndex]
   const activeMediaSource = activeCard?.image ?? ""
@@ -232,6 +239,14 @@ export function PreviewGalleryDialog({
   const playOpen = useSound(openSound, { volume: 0.3 })
   const playNext = useSound(nextSound, { volume: 0.26 })
   const playBack = useSound(backSound, { volume: 0.26 })
+
+  // Large desktop previews use the available canvas immediately. Set this in
+  // a layout effect so the portal reaches its opening-animation measurement in
+  // the intended mode, while smaller viewports retain the compact default.
+  useIsomorphicLayoutEffect(() => {
+    if (!open || prevOpenRef.current) return
+    setIsWide(shouldOpenPreviewWide())
+  }, [open])
 
   useEffect(() => {
     if (open && closeResetTimeoutRef.current !== null) {
@@ -463,6 +478,7 @@ export function PreviewGalleryDialog({
 
         <div
           className="preview-gallery-shell"
+          data-wide={isWide ? "true" : undefined}
           style={galleryMotionVars}
           onMouseDown={(event) => {
             if (event.target === event.currentTarget) {

--- a/src/index.css
+++ b/src/index.css
@@ -2539,6 +2539,10 @@ img {
   cursor: pointer;
 }
 
+.preview-gallery-shell[data-wide="true"] {
+  --preview-gallery-fixed-top: max(5vh, env(safe-area-inset-top));
+}
+
 .preview-gallery-shell[data-origin-animating] {
   overflow: hidden;
 }
@@ -2555,7 +2559,7 @@ img {
 }
 
 .preview-gallery-origin-wrap[data-wide="true"] {
-  width: min(1280px, 100%);
+  width: min(1090px, 100%);
 }
 
 .preview-gallery-popup {
@@ -2712,8 +2716,8 @@ img {
 .preview-gallery-expand {
   position: absolute;
   z-index: 3;
+  top: 0.7rem;
   right: 0.7rem;
-  bottom: 0.7rem;
   width: 40px;
   height: 40px;
   display: grid;
@@ -3218,7 +3222,8 @@ img {
 }
 
 @media (max-width: 699.98px), (hover: none), (pointer: coarse) {
-  .preview-gallery-shell {
+  .preview-gallery-shell,
+  .preview-gallery-shell[data-wide="true"] {
     --preview-gallery-fixed-top: max(clamp(1rem, 5vh, 3rem), env(safe-area-inset-top));
   }
 

--- a/tests/e2e/portfolio-polish.spec.ts
+++ b/tests/e2e/portfolio-polish.spec.ts
@@ -1323,7 +1323,7 @@ test("keeps desktop gallery navigation fixed near the modal top", async ({ page 
   const initialRailBox = await rail.boundingBox()
   expect(initialDialogBox).not.toBeNull()
   expect(initialRailBox).not.toBeNull()
-  expect(initialDialogBox!.y).toBeCloseTo(80, 0)
+  expect(initialDialogBox!.y).toBeCloseTo(50, 0)
   expect(initialRailBox!.x - (initialDialogBox!.x + initialDialogBox!.width)).toBeCloseTo(16, 0)
   expect(initialRailBox!.y + initialRailBox!.height / 2 - initialDialogBox!.y).toBeCloseTo(128, 0)
 
@@ -1356,8 +1356,34 @@ test("does not use dots to navigate between projects in the main feed", async ({
   await expect(dialog.getByRole("button", { name: /next .* image/i })).toHaveCount(0)
 })
 
+test("opens the gallery wide without clipping navigation at the large desktop breakpoint", async ({ page }) => {
+  await page.setViewportSize({ width: 1320, height: 1000 })
+  await page.emulateMedia({ reducedMotion: "reduce" })
+  await page.goto("/")
+  await page.getByRole("button", { name: /Open Matcha - Multiwallet flow/ }).click()
+
+  const dialog = page.getByRole("dialog")
+  await expect(dialog).toHaveAttribute("data-wide", "true")
+  await expect(dialog.getByRole("button", { name: "Exit wide view" })).toHaveAttribute("aria-pressed", "true")
+  const wideDialogBox = await dialog.boundingBox()
+  expect(wideDialogBox?.width).toBeCloseTo(1090, 0)
+  expect(wideDialogBox?.y).toBeCloseTo(50, 0)
+
+  const nextPreviewBox = await dialog.getByRole("button", { name: "Next preview" }).boundingBox()
+  expect(nextPreviewBox).not.toBeNull()
+  expect(nextPreviewBox!.x + nextPreviewBox!.width).toBeLessThanOrEqual(1320)
+
+  await page.setViewportSize({ width: 1280, height: 1000 })
+  await page.reload()
+  await page.getByRole("button", { name: /Open Matcha - Multiwallet flow/ }).click()
+
+  await expect(dialog).not.toHaveAttribute("data-wide", "true")
+  await expect(dialog.getByRole("button", { name: "Expand preview" })).toHaveAttribute("aria-pressed", "false")
+  expect((await dialog.boundingBox())?.y).toBeCloseTo(80, 0)
+})
+
 test("expands and restores the gallery without losing the selected preview", async ({ page }) => {
-  await page.setViewportSize({ width: 1440, height: 1000 })
+  await page.setViewportSize({ width: 1280, height: 1000 })
   await page.emulateMedia({ reducedMotion: "reduce" })
   await page.goto("/")
   await page.getByRole("button", { name: /Open Matcha - Multiwallet flow/ }).click()
@@ -1376,7 +1402,7 @@ test("expands and restores the gallery without losing the selected preview", asy
   expect(expandBox).not.toBeNull()
   expect(mediaFrameBox).not.toBeNull()
   expect(mediaFrameBox!.x + mediaFrameBox!.width - (expandBox!.x + expandBox!.width)).toBeCloseTo(11, 0)
-  expect(mediaFrameBox!.y + mediaFrameBox!.height - (expandBox!.y + expandBox!.height)).toBeCloseTo(11, 0)
+  expect(expandBox!.y - mediaFrameBox!.y).toBeCloseTo(11, 0)
 
   const compactWidth = (await dialog.boundingBox())!.width
   await expand.click()
@@ -1385,6 +1411,7 @@ test("expands and restores the gallery without losing the selected preview", asy
   await expect(dialog.getByRole("button", { name: "Exit wide view" })).toHaveAttribute("aria-pressed", "true")
   await expect(dialog.getByRole("heading", { name: "Popparazi V1" })).toBeVisible()
   await expect.poll(async () => (await dialog.boundingBox())!.width).toBeGreaterThan(compactWidth * 1.8)
+  expect((await dialog.boundingBox())?.y).toBeCloseTo(50, 0)
 
   await dialog.getByRole("button", { name: "Exit wide view" }).click()
   await expect(dialog).not.toHaveAttribute("data-wide", "true")
@@ -1431,7 +1458,6 @@ test("keeps the expanded gallery scrollable without visible scrollbars", async (
     await page.getByRole("button", { name: /Open Matcha - Multiwallet flow/ }).click()
 
     const dialog = page.getByRole("dialog")
-    await dialog.getByRole("button", { name: "Expand preview" }).click()
     await expect(dialog).toHaveAttribute("data-wide", "true")
 
     const card = dialog.locator(".preview-gallery-card")


### PR DESCRIPTION
## Summary
- Automatically open project previews in a 1090px wide view on large desktop screens.
- Move the expand control to the media top-right while preserving responsive safe-area spacing.
- Add boundary regression coverage and synchronize the design-system reference.

## Testing
- `npm run lint`
- `npm run build`
- `npm run test:e2e`
- `npm run test:design-system`