### PR TITLE
Add scroll takeover and expand portfolio

### DIFF
--- a/src/components/AboutPanel.tsx
+++ b/src/components/AboutPanel.tsx
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useEffect,
+  useId,
   useRef,
   useState,
   type CSSProperties,
@@ -12,13 +13,8 @@ import { cvEducation, cvExperience } from "../data/cv"
 import type { SiteLinks } from "../data/portfolio"
 import { trackEvent } from "../lib/analytics"
 
-export type AboutTab = "about" | "resume"
-
 type AboutPanelProps = {
   links: SiteLinks
-  // Owned by the feed so the top nav can deep-link straight into a tab.
-  activeTab: AboutTab
-  onTabChange: (tab: AboutTab) => void
 }
 
 type AboutSticker = {
@@ -42,25 +38,25 @@ type AboutSticker = {
  * movement, and they are hidden below 900px where the panel has no spare room.
  */
 const aboutStickers: AboutSticker[] = [
-  { emoji: "🌴", label: "Palm tree", top: "7%", left: "7%", rotate: -12 },
-  { emoji: "🎨", label: "Artist palette", top: "38%", left: "3%", rotate: 15 },
-  { emoji: "✏️", label: "Pencil", bottom: "28%", left: "9%", rotate: 14 },
-  { emoji: "🌊", label: "Ocean wave", bottom: "5%", left: "4%", rotate: -9 },
-  { emoji: "🗽", label: "Statue of Liberty", top: "10%", right: "8%", rotate: 9 },
-  { emoji: "💻", label: "Laptop", top: "40%", right: "3%", rotate: -6 },
-  { emoji: "🤖", label: "Robot", bottom: "30%", right: "9%", rotate: 11 },
-  { emoji: "🛠️", label: "Tools", bottom: "6%", right: "4%", rotate: -7 },
+  { emoji: "🌴", label: "Palm tree", top: "6%", left: "2%", rotate: -12 },
+  { emoji: "🎨", label: "Artist palette", top: "34%", left: "5%", rotate: 15 },
+  { emoji: "✏️", label: "Pencil", bottom: "34%", left: "2%", rotate: 14 },
+  { emoji: "🌊", label: "Ocean wave", bottom: "6%", left: "5%", rotate: -9 },
+  { emoji: "🗽", label: "Statue of Liberty", top: "10%", right: "4%", rotate: 9 },
+  { emoji: "💻", label: "Laptop", top: "38%", right: "2%", rotate: -6 },
+  { emoji: "🤖", label: "Robot", bottom: "30%", right: "5%", rotate: 11 },
+  { emoji: "🛠️", label: "Tools", bottom: "8%", right: "2%", rotate: -7 },
 ]
 
 const resumeStickers: AboutSticker[] = [
-  { emoji: "🎓", label: "Graduation cap", top: "6%", left: "5%", rotate: 10 },
-  { emoji: "🖋️", label: "Fountain pen", top: "34%", left: "8%", rotate: -14 },
-  { emoji: "☕", label: "Coffee", bottom: "30%", left: "3%", rotate: 9 },
-  { emoji: "🚀", label: "Rocket", bottom: "7%", left: "8%", rotate: -11 },
-  { emoji: "💼", label: "Briefcase", top: "9%", right: "5%", rotate: -8 },
-  { emoji: "📈", label: "Chart trending up", top: "38%", right: "9%", rotate: 12 },
-  { emoji: "💡", label: "Light bulb", bottom: "32%", right: "3%", rotate: -6 },
-  { emoji: "🏆", label: "Trophy", bottom: "6%", right: "8%", rotate: 7 },
+  { emoji: "🎓", label: "Graduation cap", top: "8%", left: "4%", rotate: 10 },
+  { emoji: "🖋️", label: "Fountain pen", top: "36%", left: "2%", rotate: -14 },
+  { emoji: "☕", label: "Coffee", bottom: "32%", left: "5%", rotate: 9 },
+  { emoji: "🚀", label: "Rocket", bottom: "6%", left: "2%", rotate: -11 },
+  { emoji: "💼", label: "Briefcase", top: "12%", right: "2%", rotate: -8 },
+  { emoji: "📈", label: "Chart trending up", top: "40%", right: "5%", rotate: 12 },
+  { emoji: "💡", label: "Light bulb", bottom: "28%", right: "2%", rotate: -6 },
+  { emoji: "🏆", label: "Trophy", bottom: "8%", right: "4%", rotate: 7 },
 ]
 
 type Offset = { x: number; y: number }
@@ -113,9 +109,9 @@ function getOffsetBounds(element: HTMLButtonElement, offset: Offset): OffsetBoun
 
 /**
  * Peel-and-move stickers. Each one keeps a bounded translation offset in state,
- * so pointer and keyboard movement survives re-renders but resets when the
- * panel is closed and reopened. The active sticker is raised above its siblings
- * and stays raised afterward, keeping overlaps in last-touched order.
+ * so pointer and keyboard movement survives re-renders. The active sticker is
+ * raised above its siblings and stays raised afterward, keeping overlaps in
+ * last-touched order.
  */
 function useStickerMovement() {
   const [offsets, setOffsets] = useState<Record<string, Offset>>({})
@@ -257,29 +253,97 @@ const elsewhereLinks = (links: SiteLinks) => [
   { name: "Dribbble", href: links.dribbble },
 ]
 
-const aboutTabs: { id: AboutTab; label: string }[] = [
-  { id: "about", label: "About me" },
-  { id: "resume", label: "Work history" },
-]
+function ResumeCompanyTooltip({ company, logoUrls }: { company: string; logoUrls: string[] }) {
+  const tooltipId = useId()
+  const [open, setOpen] = useState(false)
 
-export function AboutPanel({ links, activeTab, onTabChange }: AboutPanelProps) {
-  const tabRefs = useRef<Record<AboutTab, HTMLButtonElement | null>>({ about: null, resume: null })
+  return (
+    <button
+      type="button"
+      className="mosaic-company-inline-link mosaic-about-resume-company-trigger"
+      aria-label={`Show ${company} logos`}
+      aria-describedby={open ? tooltipId : undefined}
+      aria-expanded={open}
+      onClick={() => setOpen(true)}
+      onFocus={() => setOpen(true)}
+      onBlur={() => setOpen(false)}
+      onPointerEnter={() => {
+        if (window.matchMedia("(hover: hover)").matches) setOpen(true)
+      }}
+      onPointerLeave={(event) => {
+        if (document.activeElement !== event.currentTarget) setOpen(false)
+      }}
+      onKeyDown={(event) => {
+        if (event.key !== "Escape") return
+        setOpen(false)
+      }}
+    >
+      <span className="mosaic-company-inline-name">{company}</span>
+      <span
+        id={tooltipId}
+        role="tooltip"
+        aria-label={`${company} logos`}
+        aria-hidden={open ? undefined : true}
+        className="mosaic-company-inline-hover-logos"
+        data-open={open ? "true" : "false"}
+      >
+        {open
+          ? logoUrls.map((logoUrl) => (
+              <span key={`${company}-${logoUrl}`} className="mosaic-company-inline-hover-logo-wrap">
+                <img
+                  src={logoUrl}
+                  alt=""
+                  loading="eager"
+                  decoding="async"
+                  className="mosaic-company-inline-hover-logo"
+                />
+              </span>
+            ))
+          : null}
+      </span>
+    </button>
+  )
+}
+
+export function AboutPanel({ links }: AboutPanelProps) {
   const { offsets, order, dragging, onKeyDown, onPointerDown, onPointerMove, onPointerUp } =
     useStickerMovement()
 
-  const selectTab = (tab: AboutTab) => {
-    if (tab === activeTab) return
-    trackEvent("about_tab_change", { about_tab: tab })
-    onTabChange(tab)
-  }
+  const renderStickers = (stickers: AboutSticker[]) =>
+    stickers.map((sticker) => {
+      const offset = offsets[sticker.emoji]
+      const stackIndex = order.indexOf(sticker.emoji)
 
-  const handleTabKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
-    if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return
-    event.preventDefault()
-    const next: AboutTab = activeTab === "about" ? "resume" : "about"
-    selectTab(next)
-    tabRefs.current[next]?.focus()
-  }
+      return (
+        <button
+          key={sticker.emoji}
+          type="button"
+          aria-label={`${sticker.label} sticker. Use arrow keys to move; Home to reset.`}
+          aria-keyshortcuts="ArrowUp ArrowDown ArrowLeft ArrowRight Home"
+          className="mosaic-about-sticker"
+          data-dragging={dragging === sticker.emoji ? "" : undefined}
+          onKeyDown={(event) => onKeyDown(event, sticker.emoji)}
+          onPointerDown={(event) => onPointerDown(event, sticker.emoji)}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerCancel={onPointerUp}
+          style={
+            {
+              top: sticker.top,
+              bottom: sticker.bottom,
+              left: sticker.left,
+              right: sticker.right,
+              zIndex: stackIndex < 0 ? undefined : stackIndex + 1,
+              "--sticker-rotate": `${sticker.rotate}deg`,
+              "--sticker-x": `${offset?.x ?? 0}px`,
+              "--sticker-y": `${offset?.y ?? 0}px`,
+            } as CSSProperties
+          }
+        >
+          <span aria-hidden="true">{sticker.emoji}</span>
+        </button>
+      )
+    })
 
   return (
     <article
@@ -289,46 +353,115 @@ export function AboutPanel({ links, activeTab, onTabChange }: AboutPanelProps) {
       aria-label="About Rafael Medina"
     >
       <h2 className="sr-only">About Rafael Medina</h2>
-      <div id="about-panel-resume" className="mosaic-about-panel">
+      <div className="mosaic-about-panel">
         <div className="mosaic-about-body">
-          <div
-            className="mosaic-about-tabs"
-            role="tablist"
-            aria-label="About me or work history"
-            data-active-tab={activeTab}
+          <section
+            id="about-section"
+            className="mosaic-about-section mosaic-about-section-intro"
+            aria-labelledby="about-section-heading"
           >
-            <span className="mosaic-about-tab-indicator" aria-hidden="true" />
-            {aboutTabs.map((tab) => (
-              <button
-                key={tab.id}
-                ref={(element) => {
-                  tabRefs.current[tab.id] = element
-                }}
-                type="button"
-                role="tab"
-                id={`about-tab-${tab.id}`}
-                aria-selected={activeTab === tab.id}
-                aria-controls={`about-tabpanel-${tab.id}`}
-                tabIndex={activeTab === tab.id ? 0 : -1}
-                className="mosaic-about-tab"
-                onClick={() => selectTab(tab.id)}
-                onKeyDown={handleTabKeyDown}
-              >
-                {tab.label}
-              </button>
-            ))}
-          </div>
+            <div className="mosaic-about-section-copy">
+              <h2 id="about-section-heading" className="sr-only">
+                About me
+              </h2>
+              <p className="mosaic-about-lede">Hi, I&rsquo;m Rafael.</p>
+              <p>
+                I&rsquo;ve spent the last ten years designing products, mostly the complicated parts people
+                prefer not to think about. I figure out what to build, test it with real people, and stay
+                for the fixes after launch.
+              </p>
+              <p>
+                I prototype in code. A working interaction answers questions faster than a static mockup,
+                and usually faster than a meeting.
+              </p>
+              <p>
+                When I&rsquo;m not working, I&rsquo;m probably kickboxing, swimming, riding a bike, or being humbled
+                by salsa and jiu jitsu.
+              </p>
 
-          {/* Both panels stay mounted -- the inactive one is `hidden` -- so the
-              resume prerenders into the shipped HTML instead of being
-              client-only. */}
-          <div
-            id="about-tabpanel-resume"
-            role="tabpanel"
-            aria-labelledby="about-tab-resume"
-            className="mosaic-about-tabpanel"
-            hidden={activeTab !== "resume"}
+              <ul className="mosaic-about-hobbies">
+                {hobbies.map((hobby) => (
+                  <li key={hobby.label}>
+                    <span className="mosaic-about-hobby-emoji" aria-hidden="true">
+                      {hobby.emoji}
+                    </span>
+                    {hobby.label}
+                    {hobby.learning ? (
+                      <span className="mosaic-about-hobby-note"> (learning)</span>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+
+              <dl className="mosaic-about-facts">
+                <div className="mosaic-about-fact">
+                  <dt>Now</dt>
+                  <dd>Freelance, splitting time between Punta Cana and NYC.</dd>
+                </div>
+                <div className="mosaic-about-fact">
+                  <dt>Lately</dt>
+                  <dd>Prototypes, AI tooling, and design systems.</dd>
+                </div>
+                <div className="mosaic-about-fact">
+                  <dt>Elsewhere</dt>
+                  <dd>
+                    {elsewhereLinks(links).map((link, index) => (
+                      <span key={link.name}>
+                        {index > 0 ? <span aria-hidden="true"> · </span> : null}
+                        <a
+                          href={link.href}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="mosaic-about-link"
+                          onClick={() => {
+                            trackEvent("social_link_click", {
+                              social_label: link.name,
+                              social_href: link.href,
+                              social_placement: "about_panel",
+                            })
+                          }}
+                        >
+                          {link.name}
+                        </a>
+                      </span>
+                    ))}
+                  </dd>
+                </div>
+              </dl>
+
+              <p className="mosaic-about-closing">
+                Taking on new work. Building something?{" "}
+                <a
+                  href={`mailto:${links.email}`}
+                  className="mosaic-about-link"
+                  onClick={() => {
+                    trackEvent("social_link_click", {
+                      social_label: "Email",
+                      social_href: `mailto:${links.email}`,
+                      social_placement: "about_panel",
+                    })
+                  }}
+                >
+                  Send me an email
+                </a>
+                .
+              </p>
+            </div>
+
+            {/* Keyboard users reach the section copy before its eight movable
+                decorative stickers. The intro section owns their bounds. */}
+            {renderStickers(aboutStickers)}
+          </section>
+
+          <section
+            id="about-panel-resume"
+            className="mosaic-about-section mosaic-about-work-history"
+            aria-labelledby="about-work-history-heading"
           >
+            <div className="mosaic-about-work-history-copy">
+              <h2 id="about-work-history-heading" className="mosaic-about-section-heading">
+                Work history
+              </h2>
               <p className="mosaic-about-lede">Senior Product Designer.</p>
               <p>
                 Ten years across web3, fintech, and consumer products — from early strategy to
@@ -337,17 +470,15 @@ export function AboutPanel({ links, activeTab, onTabChange }: AboutPanelProps) {
               <ol className="mosaic-about-resume">
                 {cvExperience.map((job) => (
                   <li key={`${job.company}-${job.dates}`} className="mosaic-about-resume-entry">
-                    <h3 className="mosaic-about-resume-company">
+                    <h3
+                      className="mosaic-about-resume-company"
+                      aria-label={job.logoUrls ? job.company : undefined}
+                    >
                       {job.logoUrls ? (
-                        <span className="mosaic-about-resume-logos" aria-hidden="true">
-                          {job.logoUrls.map((logoUrl) => (
-                            <span key={logoUrl} className="mosaic-about-resume-logo-wrap">
-                              <img src={logoUrl} alt="" loading="lazy" decoding="async" />
-                            </span>
-                          ))}
-                        </span>
-                      ) : null}
-                      {job.company}
+                        <ResumeCompanyTooltip company={job.company} logoUrls={job.logoUrls} />
+                      ) : (
+                        job.company
+                      )}
                     </h3>
                     <p className="mosaic-about-resume-meta">
                       {job.role} <span aria-hidden="true">·</span> {job.dates}
@@ -378,135 +509,10 @@ export function AboutPanel({ links, activeTab, onTabChange }: AboutPanelProps) {
                 </ul>
               </div>
             </div>
-            <div
-              id="about-tabpanel-about"
-              role="tabpanel"
-              aria-labelledby="about-tab-about"
-              className="mosaic-about-tabpanel"
-              hidden={activeTab !== "about"}
-            >
-          <p className="mosaic-about-lede">Hi, I&rsquo;m Rafael.</p>
-          <p>
-            I&rsquo;ve spent the last ten years designing products, mostly the complicated parts people
-            prefer not to think about. I figure out what to build, test it with real people, and stay
-            for the fixes after launch.
-          </p>
-          <p>
-            I prototype in code. A working interaction answers questions faster than a static mockup,
-            and usually faster than a meeting.
-          </p>
-          <p>
-            When I&rsquo;m not working, I&rsquo;m probably kickboxing, swimming, riding a bike, or being humbled
-            by salsa and jiu jitsu.
-          </p>
 
-          <ul className="mosaic-about-hobbies">
-            {hobbies.map((hobby) => (
-              <li key={hobby.label}>
-                <span className="mosaic-about-hobby-emoji" aria-hidden="true">
-                  {hobby.emoji}
-                </span>
-                {hobby.label}
-                {hobby.learning ? (
-                  <span className="mosaic-about-hobby-note"> (learning)</span>
-                ) : null}
-              </li>
-            ))}
-          </ul>
-
-          <dl className="mosaic-about-facts">
-            <div className="mosaic-about-fact">
-              <dt>Now</dt>
-              <dd>Freelance, splitting time between Punta Cana and NYC.</dd>
-            </div>
-            <div className="mosaic-about-fact">
-              <dt>Lately</dt>
-              <dd>Prototypes, AI tooling, and design systems.</dd>
-            </div>
-            <div className="mosaic-about-fact">
-              <dt>Elsewhere</dt>
-              <dd>
-                {elsewhereLinks(links).map((link, index) => (
-                  <span key={link.name}>
-                    {index > 0 ? <span aria-hidden="true"> · </span> : null}
-                    <a
-                      href={link.href}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="mosaic-about-link"
-                      onClick={() => {
-                        trackEvent("social_link_click", {
-                          social_label: link.name,
-                          social_href: link.href,
-                          social_placement: "about_panel",
-                        })
-                      }}
-                    >
-                      {link.name}
-                    </a>
-                  </span>
-                ))}
-              </dd>
-            </div>
-          </dl>
-
-          <p className="mosaic-about-closing">
-            Taking on new work. Building something?{" "}
-            <a
-              href={`mailto:${links.email}`}
-              className="mosaic-about-link"
-              onClick={() => {
-                trackEvent("social_link_click", {
-                  social_label: "Email",
-                  social_href: `mailto:${links.email}`,
-                  social_placement: "about_panel",
-                })
-              }}
-            >
-              Send me an email
-            </a>
-            .
-          </p>
-            </div>
+            {renderStickers(resumeStickers)}
+          </section>
         </div>
-
-        {/* After the body on purpose: they are absolutely positioned, so the
-            visual result is identical, but keyboard users reach the tabs and
-            content before these eight decorative tab stops. */}
-        {(activeTab === "resume" ? resumeStickers : aboutStickers).map((sticker) => {
-          const offset = offsets[sticker.emoji]
-          const stackIndex = order.indexOf(sticker.emoji)
-
-          return (
-            <button
-              key={sticker.emoji}
-              type="button"
-              aria-label={`${sticker.label} sticker. Use arrow keys to move; Home to reset.`}
-              aria-keyshortcuts="ArrowUp ArrowDown ArrowLeft ArrowRight Home"
-              className="mosaic-about-sticker"
-              data-dragging={dragging === sticker.emoji ? "" : undefined}
-              onKeyDown={(event) => onKeyDown(event, sticker.emoji)}
-              onPointerDown={(event) => onPointerDown(event, sticker.emoji)}
-              onPointerMove={onPointerMove}
-              onPointerUp={onPointerUp}
-              onPointerCancel={onPointerUp}
-              style={
-                {
-                  top: sticker.top,
-                  bottom: sticker.bottom,
-                  left: sticker.left,
-                  right: sticker.right,
-                  zIndex: stackIndex < 0 ? undefined : stackIndex + 1,
-                  "--sticker-rotate": `${sticker.rotate}deg`,
-                  "--sticker-x": `${offset?.x ?? 0}px`,
-                  "--sticker-y": `${offset?.y ?? 0}px`,
-                } as CSSProperties
-              }
-            >
-              <span aria-hidden="true">{sticker.emoji}</span>
-            </button>
-          )
-        })}
       </div>
     </article>
   )

--- a/src/components/DesignSystemPage.tsx
+++ b/src/components/DesignSystemPage.tsx
@@ -104,7 +104,7 @@ const SURFACES = [
     hex: "#ffffff",
     token: "--canvas / --surface",
     name: "Page & raised",
-    note: "App's wrapper paints this across the viewport, so white is both the page and the colour of anything floating above it — hover cards, popovers, the dialog, logo chips. Every ratio on this page is measured against it.",
+    note: "App's wrapper paints this across the viewport, so white is both the page and the colour of the full-bleed About sheet and anything floating above it — hover cards, popovers, the dialog, logo chips. Every ratio on this page is measured against it.",
   },
   {
     hex: "#fdfdfc",
@@ -116,7 +116,7 @@ const SURFACES = [
     hex: "#ececee",
     token: "--mosaic-card-surface",
     name: "Tile",
-    note: "Work tiles and the about panel. The one surface that is meaningfully darker than the page.",
+    note: "Work tiles. The one surface that is meaningfully darker than the page.",
   },
   {
     hex: "#f2f2f2",
@@ -198,7 +198,7 @@ const TYPE_SCALE = [
     token: "--text-sm",
     sample: "I'm a designer who ships products.",
     spec: "0.875rem · 14px",
-    where: "Pill and tab labels, body copy, detail rows, hover-card text, wider project captions",
+    where: "Pill labels, body copy, detail rows, hover-card text, wider project captions",
     style: { fontSize: "var(--text-sm)", lineHeight: "1.25rem", letterSpacing: "-0.00563rem" },
   },
   {
@@ -219,7 +219,7 @@ const TYPE_SCALE = [
 
 const WEIGHTS = [
   { value: 400, use: "Body copy, nav links, summaries, definition values" },
-  { value: 500, use: "Pill and tab labels, preview titles, popover roles" },
+  { value: 500, use: "Pill labels, preview titles, popover roles" },
   { value: 600, use: "Headings, card titles, résumé companies, the mobile reveal, the X follow button" },
   { value: 700, use: "The X card name and stats only — vendor weight" },
 ]
@@ -229,7 +229,7 @@ const WEIGHTS = [
 const RADII = [
   {
     value: "--radius-sm · 8px",
-    use: "Chips, nav hover targets, about-panel tabs, popover links, focus rings",
+    use: "Chips, nav hover targets, popover links, focus rings",
     css: "8px",
   },
   {
@@ -239,7 +239,7 @@ const RADII = [
   },
   {
     value: "--radius-lg · 24px",
-    use: "Work tiles, the about panel, dialog media and bottom corners",
+    use: "Work tiles, dialog media and bottom corners",
     css: "24px",
   },
   { value: "--radius-full · 999px", use: "Pills, dots, avatars, nav buttons, the skip link", css: "999px" },
@@ -332,23 +332,23 @@ const EASINGS = [
     use: "The avatar's 180-degree flip and its long settle.",
   },
   {
-    name: "Tab slide",
-    css: "cubic-bezier(0.65, 0, 0.35, 1)",
-    duration: "240ms",
-    use: "The about-panel selection indicator moving between its two tabs.",
-  },
-  {
     name: "Overshoot",
     css: "cubic-bezier(0.34, 1.56, 0.64, 1)",
     duration: "220ms",
     use: "The copy-email reaction only. The single place in the system that overshoots — keep it that way.",
+  },
+  {
+    name: "About takeover",
+    css: "linear",
+    duration: "1 viewport of scroll",
+    use: "A CSS View Timeline scales and fades the complete pinned gallery as the About sheet covers it.",
   },
 ]
 
 const DURATIONS = [
   { value: "100–120ms", use: "Fallback fades, popover-content swaps, and the shortest exit feedback." },
   { value: "140–160ms", use: "Colour, opacity, and shadow on hover or focus. The default for a state change." },
-  { value: "180–240ms", use: "Anything that also moves: overlays, tab indicators, title reveals." },
+  { value: "180–240ms", use: "Anything that also moves: overlays and title reveals." },
   { value: "300ms", use: "The gallery expand/minimise icon swap." },
   { value: "360ms", use: "Media un-blurring as it decodes." },
   { value: "380–480ms", use: "First-load entrance travel, hero then mosaic." },
@@ -360,7 +360,7 @@ const DURATIONS = [
 const BREAKPOINTS = [
   { at: "≤ 327.98px", change: "Contact pills use 0.625rem side padding; location and availability stack without a separator." },
   { at: "≤ 639.98px", change: "Corner nav centres and stacks; the hero gains 6.9rem of top padding." },
-  { at: "≤ 699.98px", change: "The shell uses 8px gutters; every project shows in one 340–380px column; card captions hide." },
+  { at: "≤ 699.98px", change: "The shell uses 8px gutters; every project shows in one 340–380px column; the full-bleed About sheet returns to normal document flow; card captions hide." },
   { at: "480–699.98px + fine hover", change: "Contact pills stay 32px tall and local time uses 14px type." },
   { at: "≥ 760px", change: "This page's own two-column grids. Not a portfolio breakpoint." },
   { at: "≥ 900px", change: "Mosaic rows go to 420px and the shell drops its inline padding." },
@@ -369,6 +369,7 @@ const BREAKPOINTS = [
 
 const STACKING = [
   { z: "0–20", name: "Base, dock, chrome", note: "Tailwind's z-base / z-dock / z-chrome. The page and the mosaic." },
+  { z: "1", name: "About sheet", note: "The full-viewport white surface paints above the pinned project gallery during takeover." },
   {
     z: "30 / 50",
     name: "Corner nav",
@@ -497,8 +498,8 @@ export function DesignSystemPage({ links, name }: DesignSystemPageProps) {
                 <p>
                   On white both muted steps clear AA — <code>--muted</code> at 5.33:1 and <code>--muted-soft</code> at
                   4.61:1. On <code>--mosaic-card-surface</code> (#ececee) they fall to 4.52:1 and 3.91:1, so{" "}
-                  <code>--muted-soft</code> stops passing for normal-size text. The about panel currently uses it that
-                  way for hobby notes, definition terms, and résumé headings. On the tile surface, stop at{" "}
+                  <code>--muted-soft</code> stops passing for normal-size text. The About sheet is white, so its hobby
+                  notes, definition terms, and résumé headings can use <code>--muted-soft</code>; on work tiles, stop at{" "}
                   <code>--muted</code>.
                 </p>
               </div>
@@ -776,8 +777,7 @@ export function DesignSystemPage({ links, name }: DesignSystemPageProps) {
                 <p>
                   When one rounded box sits inside another, the outer radius is the inner radius plus the gap between
                   them. Those cases are written as <code>calc()</code> off one of the four tokens rather than measured
-                  and hard-coded: the tab group is <code>calc(var(--radius-sm) + 0.17rem)</code>, the LinkedIn card's
-                  media is <code>calc(var(--radius-md) - 5px)</code>, the preview dialog is{" "}
+                  and hard-coded: the LinkedIn card's media is <code>calc(var(--radius-md) - 5px)</code>, the preview dialog is{" "}
                   <code>calc(var(--radius-lg) + card-padding)</code>. That is how 11px, 11.5px, and 10px corners exist
                   without being scale steps — and why they stay correct when a padding changes.
                 </p>
@@ -955,8 +955,8 @@ export function DesignSystemPage({ links, name }: DesignSystemPageProps) {
                     Tile — #ececee
                   </strong>
                   <p style={{ margin: "0.4rem 0 0", color: "var(--muted)", fontSize: "var(--text-sm)", lineHeight: 1.45 }}>
-                    Work cards and the about panel. 24px radius, <code>1px solid rgb(0 0 0 / 0.08)</code>, no shadow —
-                    it sits in the page rather than above it.
+                    Work cards only. They use a 24px radius, <code>1px solid rgb(0 0 0 / 0.08)</code>, and no shadow —
+                    they sit in the page rather than above it. About uses the full-bleed white canvas surface.
                   </p>
                 </div>
                 <div className="ds-specimen" style={{ display: "block", background: "#f2f2f2" }}>
@@ -1106,6 +1106,22 @@ export function DesignSystemPage({ links, name }: DesignSystemPageProps) {
                   <strong>Row height is asserted at exactly 420px</strong> in{" "}
                   <code>tests/e2e/portfolio-polish.spec.ts</code>. Entrance animations use opacity and translate only —
                   a scale would change the measured box and fail that test.
+                </li>
+                <li>
+                  <strong>The About takeover is one viewport of scrolling.</strong> From 700px up, all four project rows
+                  remain in one sticky stage at their original sizes and 1rem gaps, followed by 2rem of breathing room.
+                  The runway is the gallery's natural height plus <code>100dvh</code>; the gallery pins when its bottom reaches the viewport, then the
+                  full-bleed white About sheet crosses it at z-index 1. The gallery retreats as one surface, and About
+                  continues in normal flow after the cover. Below 700px both wrappers collapse with{" "}
+                  <code>display: contents</code>; the white sheet stays full-bleed but no pinning or overlap is applied.
+                </li>
+                <li>
+                  <strong>About is one continuous reading surface.</strong> The introduction, Work history, and Education
+                  share one left-aligned 34rem reading axis in normal document flow. A content-width hairline separates
+                  About from Work history, with 3rem of space before the heading. Both eight-sticker sets span four
+                  vertical bands inside the outer 8% of the desktop side gutters. Work-history company names reveal
+                  their logo tooltips on hover, focus, and touch. There is no tab state or hidden panel; <code>#about-panel-resume</code> anchors
+                  directly to the visible Work history section.
                 </li>
               </ul>
             </div>

--- a/src/components/SimpleFeed.tsx
+++ b/src/components/SimpleFeed.tsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, type CSSProperties } from "react"
 import { ExternalLink } from "lucide-react"
 
-import { AboutPanel, type AboutTab } from "./AboutPanel"
+import { AboutPanel } from "./AboutPanel"
 import { ContactActionRow } from "./ContactActionRow"
 import { homeRows, linkedinHoverMedia, xProfilePreview, type PortfolioCard, type SiteLinks } from "../data/portfolio"
 import { trackEvent } from "../lib/analytics"
@@ -365,36 +365,31 @@ function LiveTimeLabel({ label, reducedMotion }: { label: string; reducedMotion:
   )
 }
 
-const sectionLinks: { label: string; tab: AboutTab; href: string }[] = [
-  { label: "About", tab: "about", href: "#about-panel" },
+const sectionLinks: { label: string; href: string }[] = [
+  { label: "About", href: "#about-panel" },
 ]
-
-function getAboutTabFromHash(hash: string): AboutTab | null {
-  if (hash === "#about-panel-resume") return "resume"
-  if (hash === "" || hash === "#about-panel") return "about"
-  return null
-}
 
 function SectionCorner({
   onSelect,
   resumeHref,
 }: {
-  onSelect: (tab: AboutTab, href: string) => void
+  onSelect: (href: string) => void
   resumeHref: string
 }) {
   return (
     <nav className="mosaic-section-corner" aria-label="Sections">
       {sectionLinks.map((link) => (
         <a
-          key={link.tab}
+          key={link.href}
           href={link.href}
           className="mosaic-social-link"
           onClick={(event) => {
             // Let modified clicks fall through so the anchor still opens in a
-            // new tab; otherwise take over so the tab can be selected first.
+            // new tab; otherwise use the same focused smooth-scroll path as
+            // the profile-photo shortcut.
             if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0) return
             event.preventDefault()
-            onSelect(link.tab, link.href)
+            onSelect(link.href)
           }}
         >
           {link.label}
@@ -498,7 +493,6 @@ export function SimpleFeed({ cards, profile, links }: SimpleFeedProps) {
     formatPuntaCanaLocalTime(new Date(globalThis.__PRERENDERED_AT__ ?? Date.now())),
   )
   const [hasCompletedWorkIntro, setHasCompletedWorkIntro] = useState(false)
-  const [aboutTab, setAboutTab] = useState<AboutTab>("about")
   const rowsRender = useMemo(() => {
     let previewIndex = 0
     return homeRows.map((row) => {
@@ -599,17 +593,6 @@ export function SimpleFeed({ cards, profile, links }: SimpleFeedProps) {
   }, [])
 
   useEffect(() => {
-    const syncAboutTabFromUrl = () => {
-      const tab = getAboutTabFromHash(window.location.hash)
-      if (tab) setAboutTab(tab)
-    }
-
-    syncAboutTabFromUrl()
-    window.addEventListener("popstate", syncAboutTabFromUrl)
-    return () => window.removeEventListener("popstate", syncAboutTabFromUrl)
-  }, [])
-
-  useEffect(() => {
     let intervalId: number | undefined
     let timeoutId: number | undefined
 
@@ -646,26 +629,16 @@ export function SimpleFeed({ cards, profile, links }: SimpleFeedProps) {
     aboutPanel.focus({ preventScroll: true })
   }
 
-  const openAboutTab = (tab: AboutTab, href: string) => {
-    if (tab !== aboutTab) {
-      trackEvent("about_tab_change", { about_tab: tab })
-      setAboutTab(tab)
-    }
+  const openAbout = (href: string) => {
     if (window.location.hash !== href) window.history.pushState(null, "", href)
-    scrollToAbout(`nav_${tab}`)
-  }
-
-  const selectAboutTab = (tab: AboutTab) => {
-    setAboutTab(tab)
-    const href = tab === "resume" ? "#about-panel-resume" : "#about-panel"
-    if (window.location.hash !== href) window.history.pushState(null, "", href)
+    scrollToAbout("nav_about")
   }
 
   return (
     <section className="mosaic-shell">
       <h1 className="sr-only">{profile.name} portfolio</h1>
       <SectionCorner
-        onSelect={openAboutTab}
+        onSelect={openAbout}
         resumeHref={links.resumePdf}
       />
       <SocialCorner timeLabel={puntaCanaTimeLabel} reducedMotion={prefersReducedMotion} />
@@ -733,89 +706,93 @@ export function SimpleFeed({ cards, profile, links }: SimpleFeedProps) {
               {/* No `prefersReducedMotion` here on purpose: it is false on the
                   server and on the first client render, so a JS gate would flash
                   before the effect syncs. Reduced motion is handled in CSS. */}
-              <div
-                className={`mosaic-rows${hasCompletedWorkIntro ? "" : " mosaic-work-intro"}`}
-                role="group"
-                aria-label="Selected work previews"
-                id="selected-work-previews"
-              >
-                {rowsRender.map((row, rowIndex) => {
-                  const rowStyle = {
-                    ...(row.height ? { "--row-height": row.height } : {}),
-                    ...(row.gap ? { "--row-gap": row.gap } : {}),
-                  } as CSSProperties
-                  const eagerRow = rowIndex === 0
-                  return (
-                    <div
-                      key={row.id}
-                      className="mosaic-row"
-                      style={rowStyle}
-                    >
-                      {row.items.map((item, itemIndex) => {
-                        const itemKey = `${item.card.id}-${item.previewIndex}`
-                        const itemStyle = {
-                          "--row-span": item.span,
-                          // Feeds the first-load stagger in `.mosaic-work-intro`.
-                          // Inert without that class, so set unconditionally.
-                          "--work-intro-row": rowIndex,
-                          "--work-intro-col": itemIndex,
-                          ...(item.width ? { flex: `0 0 ${item.width}` } : {}),
-                          ...(item.mediaMaxHeight ? { "--row-media-max-height": item.mediaMaxHeight } : {}),
-                        } as CSSProperties
-                        return (
-                          <div
-                            key={itemKey}
-                            className={`mosaic-row-item mosaic-row-item-fit-${item.fit}`}
-                            style={itemStyle}
-                            onAnimationEnd={
-                              rowIndex === rowsRender.length - 1 &&
-                              itemIndex === row.items.length - 1
-                                ? (event) => {
-                                    if (event.target === event.currentTarget) {
-                                      setHasCompletedWorkIntro(true)
-                                    }
-                                  }
-                                : undefined
-                            }
-                          >
-                            <button
-                              type="button"
-                              ref={(node) => {
-                                const nodes = previewCardNodesRef.current
-                                if (node) nodes.set(item.previewIndex, node)
-                                else nodes.delete(item.previewIndex)
-                              }}
-                              className={`mosaic-row-card mosaic-row-card-${item.card.id}`}
-                              onPointerEnter={prefetchPreviewGallery}
-                              onPointerDown={prefetchPreviewGallery}
-                              onFocus={prefetchPreviewGallery}
-                              onClick={() => {
-                                openPreview(item.card, item.previewIndex, setSelectedWorkPreviewIndex)
-                              }}
-                              aria-label={`Open ${item.card.title} preview ${item.previewIndex + 1} of ${flatWorkCards.length}`}
-                              aria-describedby={`${itemKey}-description`}
-                            >
-                              {renderRowMedia(item.card, item.card.image, item.card.title, eagerRow)}
-                              <span className="mosaic-row-card-title" aria-hidden="true">
-                                {item.card.title}
-                              </span>
-                              {/* Prerenders each project's description as real
-                                  text: crawlers get more than an aria-label,
-                                  and screen readers hear it after the label. */}
-                              <span id={`${itemKey}-description`} className="sr-only">
-                                {item.card.detail}
-                              </span>
-                            </button>
-                          </div>
-                        )
-                      })}
-                    </div>
-                  )
-                })}
+              <div className="mosaic-takeover-runway">
+                <div className="mosaic-takeover-stage">
+                  <div
+                    className={`mosaic-rows${hasCompletedWorkIntro ? "" : " mosaic-work-intro"}`}
+                    role="group"
+                    aria-label="Selected work previews"
+                    id="selected-work-previews"
+                  >
+                    {rowsRender.map((row, rowIndex) => {
+                      const rowStyle = {
+                        ...(row.height ? { "--row-height": row.height } : {}),
+                        ...(row.gap ? { "--row-gap": row.gap } : {}),
+                      } as CSSProperties
+                      const eagerRow = rowIndex === 0
+                      return (
+                        <div
+                          key={row.id}
+                          className="mosaic-row"
+                          style={rowStyle}
+                        >
+                          {row.items.map((item, itemIndex) => {
+                            const itemKey = `${item.card.id}-${item.previewIndex}`
+                            const itemStyle = {
+                              "--row-span": item.span,
+                              // Feeds the first-load stagger in `.mosaic-work-intro`.
+                              // Inert without that class, so set unconditionally.
+                              "--work-intro-row": rowIndex,
+                              "--work-intro-col": itemIndex,
+                              ...(item.width ? { flex: `0 0 ${item.width}` } : {}),
+                              ...(item.mediaMaxHeight ? { "--row-media-max-height": item.mediaMaxHeight } : {}),
+                            } as CSSProperties
+                            return (
+                              <div
+                                key={itemKey}
+                                className={`mosaic-row-item mosaic-row-item-fit-${item.fit}`}
+                                style={itemStyle}
+                                onAnimationEnd={
+                                  rowIndex === rowsRender.length - 1 &&
+                                  itemIndex === row.items.length - 1
+                                    ? (event) => {
+                                        if (event.target === event.currentTarget) {
+                                          setHasCompletedWorkIntro(true)
+                                        }
+                                      }
+                                    : undefined
+                                }
+                              >
+                                <button
+                                  type="button"
+                                  ref={(node) => {
+                                    const nodes = previewCardNodesRef.current
+                                    if (node) nodes.set(item.previewIndex, node)
+                                    else nodes.delete(item.previewIndex)
+                                  }}
+                                  className={`mosaic-row-card mosaic-row-card-${item.card.id}`}
+                                  onPointerEnter={prefetchPreviewGallery}
+                                  onPointerDown={prefetchPreviewGallery}
+                                  onFocus={prefetchPreviewGallery}
+                                  onClick={() => {
+                                    openPreview(item.card, item.previewIndex, setSelectedWorkPreviewIndex)
+                                  }}
+                                  aria-label={`Open ${item.card.title} preview ${item.previewIndex + 1} of ${flatWorkCards.length}`}
+                                  aria-describedby={`${itemKey}-description`}
+                                >
+                                  {renderRowMedia(item.card, item.card.image, item.card.title, eagerRow)}
+                                  <span className="mosaic-row-card-title" aria-hidden="true">
+                                    {item.card.title}
+                                  </span>
+                                  {/* Prerenders each project's description as real
+                                      text: crawlers get more than an aria-label,
+                                      and screen readers hear it after the label. */}
+                                  <span id={`${itemKey}-description`} className="sr-only">
+                                    {item.card.detail}
+                                  </span>
+                                </button>
+                              </div>
+                            )
+                          })}
+                        </div>
+                      )
+                    })}
+                  </div>
+                </div>
               </div>
           </article>
 
-          <AboutPanel links={links} activeTab={aboutTab} onTabChange={selectAboutTab} />
+          <AboutPanel links={links} />
 
           {/* Stays mounted after the first open so Base UI can run the close
               transition instead of the dialog vanishing on unmount. */}

--- a/src/data/cv.ts
+++ b/src/data/cv.ts
@@ -17,6 +17,13 @@ export type CvEducation = {
 
 export const cvExperience: CvExperience[] = [
   {
+    company: "Stealth",
+    location: "Remote",
+    dates: "Mar 2026 - Present",
+    role: "Founder",
+    achievements: ["Building a mobile wallet product."],
+  },
+  {
     company: "0x Project",
     location: "Remote, SF",
     dates: "Dec 2021 - Mar 2026",

--- a/src/data/portfolio.ts
+++ b/src/data/portfolio.ts
@@ -91,6 +91,16 @@ export const homeRows: HomeRow[] = [
       { cardId: "preview-shot-19", span: 1 },
     ],
   },
+  {
+    id: "row-4",
+    height: homeTileRowHeight,
+    items: [
+      { cardId: "preview-shot-14", span: 1 },
+      { cardId: "preview-shot-15", span: 1 },
+      { cardId: "preview-shot-23", span: 1 },
+      { cardId: "preview-shot-20", span: 1 },
+    ],
+  },
 ]
 
 export const siteProfile = {
@@ -278,5 +288,58 @@ export const portfolioCards: PortfolioCard[] = [
     previewHeight: 1200,
     ...matchaMeta,
     team: [collaborators.jakub],
+  },
+  {
+    id: "preview-shot-14",
+    category: "Preview",
+    title: "Matcha - Mobile Screens",
+    summary: "",
+    detail:
+      "A pass across Matcha's core mobile screens, keeping dense trading data legible and tappable on a phone-sized canvas.",
+    image: "/Projects/6842e9492c24a449a9618900_shot-small-14.jpg",
+    previewWidth: 1600,
+    previewHeight: 1200,
+    ...matchaMeta,
+    team: [collaborators.simon, collaborators.jakub],
+  },
+  {
+    id: "preview-shot-15",
+    category: "Preview",
+    title: "Matcha - Mobile navigation",
+    summary: "",
+    detail:
+      "Rethinking Matcha's mobile navigation so the core actions stayed one thumb-reach away as the product grew.",
+    image: "/Projects/6842e94938956d9ae25a45e0_shot-small-15.jpg",
+    previewWidth: 1600,
+    previewHeight: 1200,
+    ...matchaMeta,
+    team: [collaborators.simon],
+  },
+  {
+    id: "preview-shot-23",
+    category: "Preview",
+    title: "Matcha Pro",
+    summary: "",
+    detail:
+      "Matcha Pro, a denser trading view with charting and order controls for the people who live in the product all day.",
+    image: "/Projects/6842e9499838ce07a751244b_shot-small-23.jpg",
+    previewWidth: 1600,
+    previewHeight: 1200,
+    ...matchaMeta,
+    team: [collaborators.simon, collaborators.jakub],
+  },
+  {
+    id: "preview-shot-20",
+    category: "Preview",
+    title: "Matcha - Security Audit",
+    summary: "",
+    detail:
+      "Surfacing token security audits inside Matcha so traders can gauge risk before they swap, without leaving the flow.",
+    image: "/Projects/shot-small-20.webm",
+    previewWidth: 640,
+    previewHeight: 480,
+    previewPoster: "/Projects/shot-small-20-poster.webp",
+    ...matchaMeta,
+    team: [collaborators.simon, collaborators.jakub],
   },
 ]

--- a/src/index.css
+++ b/src/index.css
@@ -60,16 +60,16 @@
      next to 0.875), which is noise rather than a scale. If a new element does
      not fit one of these four, change the element, not the scale. */
   --text-xs: 0.75rem; /* 12px -- map attribution, count pills, avatar initials */
-  --text-sm: 0.875rem; /* 14px -- pill and tab labels, body copy, detail rows */
+  --text-sm: 0.875rem; /* 14px -- pill labels, body copy, detail rows */
   --text-md: 1rem; /* 16px -- card titles, prose, hero name */
   --text-lg: 1.125rem; /* 18px -- the about lede, the largest text on the site */
   /* Radius. Four steps. Anything nested is derived from one of them by the
      concentric rule (outer = inner + the padding between them) rather than
-     becoming a fifth value -- that is why the tab group and the hover-card
-     media below are calc() expressions and not new tokens. */
-  --radius-sm: 8px; /* chips, nav targets, tabs, focus rings */
+     becoming a fifth value -- that is why the hover-card media below uses a
+     calc() expression rather than a new token. */
+  --radius-sm: 8px; /* chips, nav targets, focus rings */
   --radius-md: 16px; /* hover cards, popovers, the local-time card */
-  --radius-lg: 24px; /* work tiles, the about panel, dialog media and corners */
+  --radius-lg: 24px; /* work tiles, dialog media and corners */
   --radius-full: 999px; /* pills, dots, avatars, nav buttons */
   color-scheme: light;
   text-rendering: optimizeLegibility;
@@ -764,8 +764,17 @@ img {
    fade. That has been tried three ways and does nothing. */
 
 .mosaic-about {
+  position: relative;
+  left: 50%;
+  z-index: 1;
   display: block;
-  padding: 0 clamp(16px, 3vw, 32px) clamp(3rem, 8vw, 5rem);
+  width: 100vw;
+  width: 100dvw;
+  margin-top: 0;
+  margin-left: -50vw;
+  margin-left: -50dvw;
+  padding: 0;
+  background: var(--canvas);
 }
 
 .mosaic-about:focus:not(:focus-visible) {
@@ -775,12 +784,13 @@ img {
 .mosaic-about-panel {
   position: relative;
   width: 100%;
-  min-height: clamp(26rem, 52vh, 38rem);
+  min-height: 100vh;
+  min-height: 100dvh;
   display: grid;
-  place-items: center;
-  border-radius: var(--radius-lg);
-  border: 1px solid rgb(0 0 0 / 0.08);
-  background: var(--mosaic-card-surface);
+  place-items: start center;
+  border-radius: 0;
+  border: 0;
+  background: var(--canvas);
   padding: clamp(2.5rem, 7vw, 5.5rem) clamp(1.25rem, 6vw, 5rem);
   overflow: hidden;
 }
@@ -836,11 +846,58 @@ img {
 }
 
 .mosaic-about-body {
+  width: 100%;
+  margin-top: 0;
+  display: grid;
+  gap: 0;
+  text-align: left;
+}
+
+.mosaic-about-section {
   width: min(100%, 34rem);
-  margin-top: 3.55rem;
+  margin-inline: auto;
   display: grid;
   gap: 1.05rem;
-  text-align: center;
+}
+
+.mosaic-about-section-intro {
+  position: relative;
+  width: 100%;
+}
+
+.mosaic-about-section-copy {
+  width: min(100%, 34rem);
+  margin-inline: auto;
+  display: grid;
+  gap: 1.05rem;
+  text-align: left;
+}
+
+.mosaic-about-work-history {
+  position: relative;
+  width: 100%;
+  padding-block: 1.5rem clamp(2rem, 6vw, 5rem);
+  scroll-margin-top: clamp(1rem, 4vw, 3rem);
+  text-align: left;
+}
+
+.mosaic-about-work-history-copy {
+  width: min(100%, 34rem);
+  margin-inline: auto;
+  border-top: 1px solid rgb(0 0 0 / 0.08);
+  padding-top: 3rem;
+  display: grid;
+  gap: 1.05rem;
+  text-align: left;
+}
+
+.mosaic-about-section-heading {
+  margin: 0 0 clamp(0.75rem, 2vw, 1.5rem);
+  color: #2d2d2d;
+  font-size: var(--text-lg);
+  font-weight: 600;
+  line-height: 1.5;
+  letter-spacing: -0.015rem;
 }
 
 .mosaic-about-body p {
@@ -867,7 +924,7 @@ img {
   list-style: none;
   display: flex;
   flex-wrap: wrap;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 0.5rem 1.25rem;
 }
 
@@ -901,7 +958,7 @@ img {
 .mosaic-about-fact {
   display: flex;
   flex-wrap: wrap;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: baseline;
   gap: 0.25rem 0.5rem;
 }
@@ -944,73 +1001,6 @@ img {
   padding-top: 1.25rem;
 }
 
-.mosaic-about-tabs {
-  position: absolute;
-  top: clamp(1.1rem, 2.4vw, 1.5rem);
-  left: 50%;
-  transform: translateX(-50%);
-  display: inline-grid;
-  grid-template-columns: repeat(2, 1fr);
-  padding: 0.17rem;
-  border-radius: calc(var(--radius-sm) + 0.17rem);
-  background: rgb(0 0 0 / 0.06);
-}
-
-.mosaic-about-tab-indicator {
-  position: absolute;
-  inset-block: 0.17rem;
-  left: 0.17rem;
-  width: calc((100% - 0.34rem) / 2);
-  border-radius: var(--radius-sm);
-  background: #ffffff;
-  box-shadow: 0 1px 4px rgb(46 42 42 / 0.14);
-  pointer-events: none;
-  transition: transform 240ms cubic-bezier(0.65, 0, 0.35, 1);
-}
-
-.mosaic-about-tabs[data-active-tab="resume"] .mosaic-about-tab-indicator {
-  transform: translateX(100%);
-}
-
-.mosaic-about-tab {
-  position: relative;
-  z-index: 1;
-  appearance: none;
-  border: 0;
-  background: transparent;
-  border-radius: var(--radius-sm);
-  min-height: 1.75rem;
-  padding: 0 0.8rem;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Inter", sans-serif;
-  font-size: var(--text-sm);
-  font-weight: 500;
-  letter-spacing: -0.00563rem;
-  white-space: nowrap;
-  text-wrap: nowrap;
-  color: var(--muted);
-  cursor: pointer;
-  transition: color 160ms ease;
-}
-
-.mosaic-about-tab:hover {
-  color: #2d2d2d;
-}
-
-.mosaic-about-tab[aria-selected="true"] {
-  color: #2d2d2d;
-}
-
-.mosaic-about-tabpanel {
-  display: grid;
-  gap: 1.05rem;
-}
-
-/* `display: grid` above would otherwise beat the UA's [hidden] rule, and the
-   inactive tab panel now stays mounted so it prerenders. */
-.mosaic-about-tabpanel[hidden] {
-  display: none;
-}
-
 .mosaic-about-resume {
   margin: 0.35rem 0 0;
   padding: 0;
@@ -1028,37 +1018,32 @@ img {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 0.5rem;
   font-weight: 600;
   line-height: 1.5;
   color: #2d2d2d;
 }
 
-.mosaic-about-resume-logos {
-  display: inline-flex;
+.mosaic-about-resume-company-trigger {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  padding: 0;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
 }
 
-.mosaic-about-resume-logo-wrap {
-  display: inline-flex;
-  width: 1.35rem;
-  height: 1.35rem;
-  align-items: center;
-  justify-content: center;
-  padding: 0.29rem;
-  border-radius: var(--radius-full);
-  background: #ffffff;
-  box-shadow: inset 0 0 0 1px rgb(0 0 0 / 0.05);
-}
-
-.mosaic-about-resume-logo-wrap + .mosaic-about-resume-logo-wrap {
-  margin-left: -0.26rem;
-}
-
-.mosaic-about-resume-logo-wrap img {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
+.mosaic-about-resume-company-trigger .mosaic-company-inline-hover-logos[data-open="true"] {
+  opacity: 1;
+  visibility: visible;
+  transform:
+    perspective(920px)
+    translate(calc(-50% + var(--mosaic-hover-anchor-x)), var(--mosaic-hover-anchor-y))
+    rotateX(var(--mosaic-hover-tilt-x))
+    rotateY(var(--mosaic-hover-tilt-y))
+    scale(var(--mosaic-hover-lift));
 }
 
 .mosaic-about-body .mosaic-about-resume-meta {
@@ -2304,10 +2289,96 @@ img {
   min-height: var(--row-height, 320px);
 }
 
+/* The wrappers disappear on compact screens, where the stacked project rows
+   are taller than the viewport and cannot become a useful pinned background. */
+.mosaic-takeover-runway,
+.mosaic-takeover-stage {
+  display: contents;
+}
+
+@keyframes mosaic-takeover-retreat {
+  from {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  to {
+    opacity: 0.78;
+    transform: scale(0.98);
+  }
+}
+
+@media (min-width: 700px) {
+  .mosaic-shell {
+    timeline-scope: --about-takeover;
+  }
+
+  /* The runway adds one viewport after the gallery. Its sticky child keeps the
+     complete grid intact and pins only when the grid's bottom reaches the
+     viewport, leaving About one viewport of space to cross it. */
+  .mosaic-rows {
+    padding-bottom: 2rem;
+  }
+
+  .mosaic-takeover-runway {
+    --takeover-row-height: clamp(180px, 16vw, 260px);
+    --takeover-gallery-height: calc(
+      var(--takeover-row-height) + var(--takeover-row-height) + var(--takeover-row-height) +
+        var(--takeover-row-height) + 5rem
+    );
+
+    position: relative;
+    width: 100%;
+    height: calc(var(--takeover-gallery-height) + 100vh);
+    height: calc(var(--takeover-gallery-height) + 100dvh);
+    display: block;
+  }
+
+  .mosaic-takeover-stage {
+    position: sticky;
+    top: calc(100vh - var(--takeover-gallery-height));
+    top: calc(100dvh - var(--takeover-gallery-height));
+    z-index: 0;
+    width: 100%;
+    height: var(--takeover-gallery-height);
+    display: block;
+    transform-origin: center bottom;
+  }
+
+  .mosaic-takeover-stage .mosaic-rows {
+    width: 100%;
+  }
+
+  .mosaic-about {
+    margin-top: -100vh;
+    margin-top: -100dvh;
+    view-timeline-name: --about-takeover;
+    view-timeline-axis: block;
+  }
+}
+
+@media (min-width: 700px) and (prefers-reduced-motion: no-preference) {
+  /* View Timelines keep scroll-linked motion off the main thread. The complete
+     gallery retreats as one composited surface, preserving every card gap and
+     avoiding continuously painted blur. */
+  .mosaic-takeover-stage {
+    animation-name: mosaic-takeover-retreat;
+    animation-duration: 1ms;
+    animation-timing-function: linear;
+    animation-fill-mode: both;
+    animation-timeline: --about-takeover;
+    animation-range: entry 0% entry 100%;
+  }
+}
+
 /* Taller cards on desktop. `--row-height` is set inline from the row data, so
    `!important` is what it takes to win the cascade against an inline custom
    property. Folding the breakpoint into the data model would be cleaner. */
 @media (min-width: 900px) {
+  .mosaic-takeover-runway {
+    --takeover-row-height: 420px;
+  }
+
   .mosaic-row {
     --row-height: 420px !important;
   }
@@ -2443,7 +2514,6 @@ img {
     min-height: 44px;
   }
 
-  .mosaic-about-tab,
   .mosaic-about-link {
     min-height: 40px;
   }

--- a/tests/design-system/design-system.spec.ts
+++ b/tests/design-system/design-system.spec.ts
@@ -59,13 +59,11 @@ test("documents component-specific motion curves that still ship", async ({ page
     const firstBezier = (value: string) => value.match(/cubic-bezier\([^)]*\)/)?.[0] ?? ""
     const hero = getComputedStyle(document.querySelector(".mosaic-hero") as Element)
     const avatar = getComputedStyle(document.querySelector(".mosaic-avatar-coin-inner") as Element)
-    const tabs = getComputedStyle(document.querySelector(".mosaic-about-tab-indicator") as Element)
     const workHistory = getComputedStyle(document.querySelector(".mosaic-work-history") as Element)
 
     return [
       firstBezier(hero.transitionTimingFunction),
       firstBezier(avatar.transitionTimingFunction),
-      firstBezier(tabs.transitionTimingFunction),
       firstBezier(workHistory.getPropertyValue("--mosaic-popover-exit-ease")),
     ]
   })

--- a/tests/e2e/portfolio-polish.spec.ts
+++ b/tests/e2e/portfolio-polish.spec.ts
@@ -17,13 +17,12 @@ const stubCompanySite = (context: BrowserContext) =>
 // The work cards cascade in on first load, so a card clicked straight after
 // `goto` can still be sitting at its pre-start offset -- and the gallery grows
 // out of that card's live rect. Settle the cascade before touching a card.
-// Safe from hanging: nothing in index.css animates infinitely.
+// Safe from hanging: the gallery's View Timeline lives on the parent stage,
+// outside this subtree, while every animation inside `.mosaic-rows` finishes.
 const settleWorkCards = (page: Page) =>
   page
     .locator(".mosaic-rows")
-    .evaluate((element) =>
-      Promise.all(element.getAnimations({ subtree: true }).map((animation) => animation.finished)),
-    )
+    .evaluate((element) => Promise.all(element.getAnimations({ subtree: true }).map((animation) => animation.finished)))
 
 const pausePageClock = async (page: Page) => {
   await page.clock.install({ time: new Date("2026-08-18T12:00:00Z") })
@@ -159,9 +158,8 @@ test("keeps company chips compact with comfortable mobile targets", async ({ pag
 test("reserves balanced wrapping for headings", async ({ page }) => {
   await page.setViewportSize(mobileViewport)
   await page.goto("/")
-  await page.getByRole("tab", { name: "About me" }).click()
 
-  await expect(page.locator("#about-tabpanel-about > p").nth(1)).toHaveCSS("text-wrap", "pretty")
+  await expect(page.locator("#about-section .mosaic-about-section-copy > p").nth(1)).toHaveCSS("text-wrap", "pretty")
   await expect(page.getByRole("button", { name: "Copy email" })).not.toHaveCSS("text-wrap", "balance")
 })
 
@@ -761,37 +759,11 @@ test("reveals an external-link icon when the resume link is hovered", async ({ p
   await expect(externalIcon).toHaveCSS("opacity", "1")
 })
 
-test("keeps the about me toggle label on one line on mobile", async ({ page }) => {
+test("gives about links comfortable mobile targets", async ({ page }) => {
   await page.setViewportSize(mobileViewport)
   await page.goto("/")
 
-  const lineCount = await page.getByRole("tab", { name: "about me" }).evaluate((tab) => {
-    const range = document.createRange()
-    range.selectNodeContents(tab)
-    return range.getClientRects().length
-  })
-
-  expect(lineCount).toBe(1)
-})
-
-test("gives the about switcher comfortable mobile targets", async ({ page }) => {
-  await page.setViewportSize(mobileViewport)
-  await page.goto("/")
-
-  const tabs = page.getByRole("tablist", { name: "About me or work history" }).getByRole("tab")
-  for (const tab of await tabs.all()) {
-    const box = await tab.boundingBox()
-    expect(box).not.toBeNull()
-    expect(box!.height).toBeGreaterThanOrEqual(40)
-  }
-})
-
-test("gives about panel links comfortable mobile targets", async ({ page }) => {
-  await page.setViewportSize(mobileViewport)
-  await page.goto("/")
-  await page.getByRole("tab", { name: "About me" }).click()
-
-  const links = page.locator("#about-tabpanel-about .mosaic-about-link")
+  const links = page.locator("#about-section .mosaic-about-link")
   expect(await links.count()).toBeGreaterThan(0)
   for (const link of await links.all()) {
     const box = await link.boundingBox()
@@ -800,38 +772,77 @@ test("gives about panel links comfortable mobile targets", async ({ page }) => {
   }
 })
 
-test("labels the about panel tabs", async ({ page }) => {
+test("stacks about before work history without tab controls", async ({ page }) => {
   await page.goto("/")
 
-  const tabs = page.getByRole("tablist", { name: "About me or work history" })
-  await expect(tabs.getByRole("tab").nth(0)).toHaveText("About me")
-  await expect(tabs.getByRole("tab").nth(1)).toHaveText("Work history")
-})
+  const about = page.locator("#about-section")
+  const workHistory = page.locator("#about-panel-resume")
+  await expect(page.getByRole("tablist")).toHaveCount(0)
+  await expect(about.getByText(/Hi, I.m Rafael/)).toBeVisible()
+  await expect(workHistory.getByRole("heading", { name: "Work history" })).toBeVisible()
 
-test("uses compact corners for the about panel tabs", async ({ page }) => {
-  await page.goto("/#about-panel")
-
-  const tablist = page.getByRole("tablist", { name: "About me or work history" })
-  const tabs = tablist.getByRole("tab")
-
-  for (const tab of await tabs.all()) {
-    await expect(tab).toHaveCSS("border-radius", "8px")
-  }
-
-  // The group's corner is the tab's corner plus the padding between them, so the
-  // two curves stay concentric. That value is derived in CSS from --radius-sm
-  // rather than hard-coded, so assert the relationship instead of a literal --
-  // it has to survive a change to either the token or the padding.
-  const corners = await tablist.evaluate((element) => {
-    const tab = element.querySelector('[role="tab"]')
+  const order = await page.locator("#about-section, #about-panel-resume").evaluateAll(([aboutNode, workNode]) => {
+    const aboutRect = aboutNode.getBoundingClientRect()
+    const workRect = workNode.getBoundingClientRect()
     return {
-      group: parseFloat(getComputedStyle(element).borderTopLeftRadius),
-      tab: parseFloat(getComputedStyle(tab as Element).borderTopLeftRadius),
-      padding: parseFloat(getComputedStyle(element).paddingTop),
+      followsAbout: Boolean(aboutNode.compareDocumentPosition(workNode) & Node.DOCUMENT_POSITION_FOLLOWING),
+      startsBelowAbout: workRect.top >= aboutRect.bottom,
     }
   })
 
-  expect(corners.group).toBeCloseTo(corners.tab + corners.padding, 1)
+  expect(order).toEqual({ followsAbout: true, startsBelowAbout: true })
+})
+
+test("left aligns the about introduction with the work-history reading axis", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 })
+  await page.goto("/")
+
+  const alignment = await page.locator(".mosaic-about-section-copy, .mosaic-about-work-history-copy").evaluateAll(
+    ([aboutCopy, workHistoryCopy]) => {
+      const aboutRect = aboutCopy.getBoundingClientRect()
+      const workHistoryRect = workHistoryCopy.getBoundingClientRect()
+      const hobbies = aboutCopy.querySelector(".mosaic-about-hobbies")
+      const fact = aboutCopy.querySelector(".mosaic-about-fact")
+
+      return {
+        sharedLeftEdge: Math.round(aboutRect.left) === Math.round(workHistoryRect.left),
+        aboutTextAlign: getComputedStyle(aboutCopy).textAlign,
+        hobbiesJustification: hobbies ? getComputedStyle(hobbies).justifyContent : null,
+        factsJustification: fact ? getComputedStyle(fact).justifyContent : null,
+      }
+    },
+  )
+
+  expect(alignment).toEqual({
+    sharedLeftEdge: true,
+    aboutTextAlign: "left",
+    hobbiesJustification: "flex-start",
+    factsJustification: "flex-start",
+  })
+})
+
+test("separates work history from about with a content-width divider", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 })
+  await page.goto("/")
+
+  const divider = await page.locator(".mosaic-about-work-history-copy").evaluate((element) => {
+    const styles = getComputedStyle(element)
+    return {
+      width: Math.round(element.getBoundingClientRect().width),
+      borderTopWidth: styles.borderTopWidth,
+      borderTopStyle: styles.borderTopStyle,
+      borderTopColor: styles.borderTopColor,
+      paddingTop: styles.paddingTop,
+    }
+  })
+
+  expect(divider).toEqual({
+    width: 544,
+    borderTopWidth: "1px",
+    borderTopStyle: "solid",
+    borderTopColor: "rgba(0, 0, 0, 0.08)",
+    paddingTop: "48px",
+  })
 })
 
 test("scrolls to and focuses the about section from the avatar button", async ({ page }) => {
@@ -851,29 +862,205 @@ test("scrolls to and focuses the about section from the avatar button", async ({
   await expect(about).not.toHaveCSS("outline-style", "none")
 })
 
-test("keeps the about section below the portfolio cards", async ({ page }) => {
+test("keeps every project row together inside the takeover stage", async ({ page }) => {
+  await page.setViewportSize({ width: 1728, height: 913 })
   await page.goto("/")
 
-  const work = page.locator("#work")
-  const about = page.locator("#about-panel")
+  const stage = page.locator(".mosaic-takeover-stage")
+  const rows = stage.locator(".mosaic-row")
 
-  await expect(work).toBeVisible()
-  await expect(about).toBeVisible()
+  await expect(rows).toHaveCount(4)
 
-  const placement = await page.locator("#work, #about-panel").evaluateAll(([workNode, aboutNode]) => {
-    const workRect = workNode.getBoundingClientRect()
-    const aboutRect = aboutNode.getBoundingClientRect()
+  const gaps = await rows.evaluateAll((elements) =>
+    elements.slice(1).map((element, index) => {
+      const previousRect = elements[index].getBoundingClientRect()
+      return Math.round(element.getBoundingClientRect().top - previousRect.bottom)
+    }),
+  )
+
+  expect(gaps).toEqual([16, 16, 16])
+})
+
+test("leaves breathing room after the final project row before the about takeover", async ({ page }) => {
+  await page.setViewportSize({ width: 1728, height: 913 })
+  await page.goto("/")
+
+  const stage = page.locator(".mosaic-takeover-stage")
+  await stage.evaluate((element) => element.scrollIntoView({ block: "end" }))
+
+  const endSpacing = await stage.evaluate((element) => {
+    const lastRow = element.querySelector(".mosaic-row:last-child")
+    if (!lastRow) return null
+
+    return Math.round(element.getBoundingClientRect().bottom - lastRow.getBoundingClientRect().bottom)
+  })
+
+  expect(endSpacing).toBe(32)
+})
+
+test("pins the complete project grid when its bottom reaches the viewport", async ({ page }) => {
+  await page.setViewportSize({ width: 1728, height: 913 })
+  await page.goto("/")
+
+  const stage = page.locator(".mosaic-takeover-stage")
+  await stage.evaluate((element) => element.scrollIntoView({ block: "end" }))
+
+  const placement = await stage.evaluate((element) => {
+    const aboutNode = document.querySelector("#about-panel")
+    if (!aboutNode) return null
+    const stageRect = element.getBoundingClientRect()
     return {
-      followsWork: Boolean(workNode.compareDocumentPosition(aboutNode) & Node.DOCUMENT_POSITION_FOLLOWING),
-      startsAfterWork: aboutRect.top >= workRect.bottom,
+      stageTop: Math.round(stageRect.top),
+      stageBottom: Math.round(stageRect.bottom),
+      stageHeight: Math.round(stageRect.height),
+      stagePosition: getComputedStyle(element).position,
+      aboutTop: Math.round(aboutNode.getBoundingClientRect().top),
     }
   })
 
-  expect(placement).toEqual({ followsWork: true, startsAfterWork: true })
+  expect(placement).toEqual({
+    stageTop: -847,
+    stageBottom: 913,
+    stageHeight: 1760,
+    stagePosition: "sticky",
+    aboutTop: 913,
+  })
 })
 
-test("matches the selected-work bottom padding to the card spacing", async ({ page }) => {
+test("scrolls the about surface over the pinned project grid", async ({ page }) => {
   await page.setViewportSize({ width: 1728, height: 913 })
+  await page.goto("/")
+
+  const stage = page.locator(".mosaic-takeover-stage")
+  await stage.evaluate((element) => element.scrollIntoView({ block: "end" }))
+  await page.evaluate(() => window.scrollBy(0, Math.round(window.innerHeight / 2)))
+
+  const placement = await stage.evaluate((element) => {
+    const aboutNode = document.querySelector("#about-panel")
+    if (!aboutNode) return null
+    const stageRect = element.getBoundingClientRect()
+    const aboutRect = aboutNode.getBoundingClientRect()
+    const topmostNode = document.elementFromPoint(aboutRect.left + aboutRect.width / 2, aboutRect.top + 24)
+    return {
+      stageBottom: Math.round(stageRect.bottom),
+      aboutTop: Math.round(aboutRect.top),
+      aboutOwnsCoveredArea: Boolean(topmostNode?.closest("#about-panel")),
+    }
+  })
+
+  expect(placement).toEqual({ stageBottom: 913, aboutTop: 456, aboutOwnsCoveredArea: true })
+})
+
+test("retreats the complete project grid as one surface during takeover", async ({ page }) => {
+  await page.setViewportSize({ width: 1728, height: 913 })
+  await page.emulateMedia({ reducedMotion: "no-preference" })
+  await page.goto("/")
+
+  const stage = page.locator(".mosaic-takeover-stage")
+  await stage.evaluate((element) => element.scrollIntoView({ block: "end" }))
+  await page.evaluate(() => window.scrollBy(0, Math.round(window.innerHeight / 2)))
+  await page.evaluate(() => new Promise(requestAnimationFrame))
+
+  const retreat = await stage.evaluate((element) => {
+    const styles = getComputedStyle(element)
+    return { opacity: Number.parseFloat(styles.opacity), transform: styles.transform }
+  })
+  const card = stage.locator(".mosaic-row-card").first()
+
+  expect(retreat.opacity).toBeLessThan(0.95)
+  expect(retreat.transform).not.toBe("none")
+  await expect(card).toHaveCSS("opacity", "1")
+  await expect(card).toHaveCSS("transform", "none")
+})
+
+test("keeps the takeover cover but removes retreat motion for reduced motion", async ({ page }) => {
+  await page.setViewportSize({ width: 1728, height: 913 })
+  await page.emulateMedia({ reducedMotion: "reduce" })
+  await page.goto("/")
+
+  const stage = page.locator(".mosaic-takeover-stage")
+  await stage.evaluate((element) => element.scrollIntoView({ block: "end" }))
+  await page.evaluate(() => window.scrollBy(0, Math.round(window.innerHeight / 2)))
+
+  const stageBottom = await stage.evaluate((element) => Math.round(element.getBoundingClientRect().bottom))
+  const aboutTop = await page.locator("#about-panel").evaluate((element) =>
+    Math.round(element.getBoundingClientRect().top),
+  )
+
+  expect(stageBottom).toBe(913)
+  expect(aboutTop).toBe(456)
+  await expect(stage).toHaveCSS("opacity", "1")
+  await expect(stage).toHaveCSS("transform", "none")
+})
+
+test("releases the about sheet into normal document scrolling after takeover", async ({ page }) => {
+  await page.setViewportSize({ width: 1728, height: 700 })
+  await page.goto("/")
+
+  const stage = page.locator(".mosaic-takeover-stage")
+  const about = page.locator("#about-panel")
+  await stage.evaluate((element) => element.scrollIntoView({ block: "end" }))
+  await page.evaluate(() => window.scrollBy(0, window.innerHeight))
+
+  const beforeTop = await about.evaluate((element) => element.getBoundingClientRect().top)
+  await page.evaluate(() => window.scrollBy(0, 80))
+
+  const placement = await about.evaluate(
+    (element, initialTop) => ({
+      position: getComputedStyle(element).position,
+      distanceMoved: Math.round(initialTop - element.getBoundingClientRect().top),
+    }),
+    beforeTop,
+  )
+
+  expect(placement).toEqual({ position: "relative", distanceMoved: 80 })
+})
+
+test("uses normal-flow project and about sections on mobile", async ({ page }) => {
+  await page.setViewportSize(mobileViewport)
+  await page.goto("/")
+
+  const stage = page.locator(".mosaic-takeover-stage")
+  const placement = await page.locator("#work, #about-panel").evaluateAll(([workNode, aboutNode]) => ({
+    overlap: Math.round(workNode.getBoundingClientRect().bottom - aboutNode.getBoundingClientRect().top),
+    hasHorizontalOverflow: document.documentElement.scrollWidth > document.documentElement.clientWidth,
+  }))
+
+  await expect(stage).toHaveCSS("display", "contents")
+  expect(placement).toEqual({ overlap: 0, hasHorizontalOverflow: false })
+})
+
+test("uses a full-bleed white viewport surface for about on desktop", async ({ page }) => {
+  await page.setViewportSize({ width: 1728, height: 913 })
+  await page.goto("/")
+
+  const surface = await page.locator("#about-panel").evaluate((element) => {
+    const panel = element.querySelector(".mosaic-about-panel")
+    if (!panel) return null
+    const rect = element.getBoundingClientRect()
+    const panelStyles = getComputedStyle(panel)
+    return {
+      left: Math.round(rect.left),
+      width: Math.round(rect.width),
+      minHeight: Math.round(Number.parseFloat(panelStyles.minHeight)),
+      radius: panelStyles.borderRadius,
+      borderWidth: panelStyles.borderTopWidth,
+      background: panelStyles.backgroundColor,
+    }
+  })
+
+  expect(surface).toEqual({
+    left: 0,
+    width: 1728,
+    minHeight: 913,
+    radius: "0px",
+    borderWidth: "0px",
+    background: "rgb(255, 255, 255)",
+  })
+})
+
+test("matches the selected-work bottom padding to the card spacing on mobile", async ({ page }) => {
+  await page.setViewportSize(mobileViewport)
   await page.goto("/")
 
   const spacing = await page.locator("#selected-work-previews").evaluate((element) => {
@@ -889,7 +1076,7 @@ test("shows every project immediately on mobile", async ({ page }) => {
   await page.goto("/")
 
   const rows = page.locator(".mosaic-row")
-  await expect(rows).toHaveCount(3)
+  await expect(rows).toHaveCount(4)
   await expect(rows.first()).toBeVisible()
   await expect(rows.nth(1)).toBeVisible()
   await expect(rows.last()).toBeVisible()
@@ -960,17 +1147,36 @@ test("keeps the restored third-row projects equal width", async ({ page }) => {
   expect(tradePageBox!.width).toBeCloseTo(tradeModuleBox!.width, 0)
 })
 
-test("omits retired Matcha projects from selected work", async ({ page }) => {
+test("adds four more projects in the fourth row", async ({ page }) => {
   await page.goto("/")
 
-  for (const title of [
-    "Matcha - Security Audit",
-    "Matcha Pro",
-    "Matcha - Mobile navigation",
-    "Matcha - Mobile Screens",
-  ]) {
-    await expect(page.getByRole("button", { name: new RegExp(`Open ${title}`) })).toHaveCount(0)
-  }
+  const rows = page.locator(".mosaic-row")
+  const lastRow = rows.last()
+  const cards = lastRow.locator(".mosaic-row-card")
+
+  await expect(rows).toHaveCount(4)
+  await expect(cards).toHaveCount(4)
+  await expect(cards.nth(0)).toHaveAttribute("aria-label", /Open Matcha - Mobile Screens/)
+  await expect(cards.nth(1)).toHaveAttribute("aria-label", /Open Matcha - Mobile navigation/)
+  await expect(cards.nth(2)).toHaveAttribute("aria-label", /Open Matcha Pro/)
+  await expect(cards.nth(3)).toHaveAttribute("aria-label", /Open Matcha - Security Audit/)
+  await expect(cards.nth(0).locator("img")).toHaveAttribute("src", /shot-small-14\.jpg$/)
+  await expect(cards.nth(1).locator("img")).toHaveAttribute("src", /shot-small-15\.jpg$/)
+  await expect(cards.nth(2).locator("img")).toHaveAttribute("src", /shot-small-23\.jpg$/)
+  await expect(cards.nth(3).locator("video")).toHaveAttribute("poster", "/Projects/shot-small-20-poster.webp")
+})
+
+test("keeps the fourth-row projects equal width", async ({ page }) => {
+  await page.setViewportSize({ width: 2560, height: 1239 })
+  await page.goto("/")
+
+  const cards = page.locator(".mosaic-row").last().locator(".mosaic-row-card")
+  await expect(cards).toHaveCount(4)
+  const widths = await cards.evaluateAll((elements) =>
+    elements.map((element) => Math.round(element.getBoundingClientRect().width)),
+  )
+
+  expect(new Set(widths).size).toBe(1)
 })
 
 test("moves directly from selected work to about without a repeated contact card", async ({ page }) => {
@@ -1050,7 +1256,7 @@ test("keeps gallery controls inside the mobile viewport and exposes a close butt
       }),
     )
   })
-  await expect(dialog.getByText("2 / 8", { exact: true })).toBeVisible()
+  await expect(dialog.getByText("2 / 12", { exact: true })).toBeVisible()
 
   await dialog.getByRole("button", { name: "Close preview" }).click()
   await expect(dialog).toBeHidden()
@@ -1077,7 +1283,7 @@ test("treats a mostly vertical touch gesture as scrolling rather than gallery pa
     element.dispatchEvent(new TouchEvent("touchend", { bubbles: true, changedTouches: [end] }))
   })
 
-  await expect(page.locator(".preview-gallery-count")).toHaveText("1 / 8")
+  await expect(page.locator(".preview-gallery-count")).toHaveText("1 / 12")
   await context.close()
 })
 
@@ -1114,7 +1320,7 @@ test("clears a cancelled gallery gesture before accepting the next horizontal sw
     const staleEnd = new Touch({ identifier: 1, target: element, clientX: 160, clientY: 180 })
     element.dispatchEvent(new TouchEvent("touchend", { bubbles: true, changedTouches: [staleEnd] }))
   })
-  await expect(page.locator(".preview-gallery-count")).toHaveText("1 / 8")
+  await expect(page.locator(".preview-gallery-count")).toHaveText("1 / 12")
 
   await card.evaluate((element) => {
     const start = new Touch({ identifier: 2, target: element, clientX: 280, clientY: 180 })
@@ -1124,7 +1330,7 @@ test("clears a cancelled gallery gesture before accepting the next horizontal sw
     )
     element.dispatchEvent(new TouchEvent("touchend", { bubbles: true, changedTouches: [end] }))
   })
-  await expect(page.locator(".preview-gallery-count")).toHaveText("2 / 8")
+  await expect(page.locator(".preview-gallery-count")).toHaveText("2 / 12")
   await context.close()
 })
 
@@ -1168,20 +1374,18 @@ test("opens the gallery after an intent prefetch fails", async ({ page }) => {
   expect(errors).toEqual([])
 })
 
-test("switches the about card between about me and work history", async ({ page }) => {
+test("shows about and the complete work history together", async ({ page }) => {
   await page.goto("/")
   const panel = page.locator("#about-panel")
 
-  // Both tab panels stay mounted so the resume prerenders; the inactive one is
-  // `hidden`, so assert visibility rather than DOM presence.
   await expect(panel.getByText(/Hi, I.m Rafael/)).toBeVisible()
-
-  await panel.getByRole("tab", { name: "Work history" }).click()
-  await expect(panel.getByRole("tab", { name: "Work history" })).toHaveAttribute("aria-selected", "true")
-  await expect(panel.getByText(/Hi, I.m Rafael/)).toBeHidden()
+  await expect(panel.getByRole("heading", { name: "Work history" })).toBeVisible()
 
   const entries = panel.locator(".mosaic-about-resume-entry")
-  await expect(entries.first()).toContainText("0x Project")
+  await expect(entries.first()).toContainText("Stealth")
+  await expect(entries.first()).toContainText("Founder · Mar 2026 - Present")
+  await expect(entries.first()).toContainText("Building a mobile wallet product.")
+  await expect(entries.nth(1)).toContainText("0x Project")
   await expect(panel).toContainText("Incubeta")
   await expect(panel).toContainText("NOVA Community College")
   await expect(panel).toContainText("ITLA")
@@ -1197,58 +1401,156 @@ test("switches the about card between about me and work history", async ({ page 
     "_blank",
   )
 
+  await expect(panel.getByRole("button", { name: /Palm tree sticker/ })).toBeVisible()
   await expect(panel.getByRole("button", { name: /Briefcase sticker/ })).toBeVisible()
-  await expect(panel.getByRole("button", { name: /Palm tree sticker/ })).toHaveCount(0)
-
-  await panel.getByRole("tab", { name: "Work history" }).press("ArrowLeft")
-  await expect(panel.getByRole("tab", { name: "about me" })).toHaveAttribute("aria-selected", "true")
-  await expect(panel.getByText(/Hi, I.m Rafael/)).toBeVisible()
 })
 
-test("slides one shared selection pill between the about tabs", async ({ page }) => {
+test("keeps work-history stickers inside the work-history section", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 })
+  await page.goto("/#about-panel-resume")
+
+  const workHistory = page.locator("#about-panel-resume")
+  const sticker = page.getByRole("button", { name: /Briefcase sticker/ })
+
+  await expect(sticker).toBeVisible()
+  expect(await sticker.evaluate((element) => element.parentElement?.id)).toBe("about-panel-resume")
+
+  const bounds = await Promise.all([workHistory.boundingBox(), sticker.boundingBox()])
+  expect(bounds[0]).not.toBeNull()
+  expect(bounds[1]).not.toBeNull()
+  expect(bounds[1]!.x).toBeGreaterThanOrEqual(bounds[0]!.x)
+  expect(bounds[1]!.x + bounds[1]!.width).toBeLessThanOrEqual(bounds[0]!.x + bounds[0]!.width)
+})
+
+test("spreads each sticker set across the full desktop section gutters", async ({ page }) => {
+  await page.setViewportSize({ width: 2560, height: 1239 })
+  await page.goto("/#about-panel")
+
+  const layouts = await page.locator("#about-section, #about-panel-resume").evaluateAll((sections) =>
+    sections.map((section) => {
+      const sectionRect = section.getBoundingClientRect()
+      const stickers = Array.from(section.querySelectorAll<HTMLElement>(".mosaic-about-sticker"))
+      const centers = stickers.map((sticker) => {
+        const rect = sticker.getBoundingClientRect()
+        return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 }
+      })
+      const nearestEdgeInsets = centers.map(({ x }) =>
+        Math.min(x - sectionRect.left, sectionRect.right - x),
+      )
+      const verticalCenters = centers.map(({ y }) => y)
+
+      return {
+        stickerCount: stickers.length,
+        allInOuterGutters: nearestEdgeInsets.every((inset) => inset <= sectionRect.width * 0.08),
+        verticalCoverage:
+          verticalCenters.length > 0
+            ? (Math.max(...verticalCenters) - Math.min(...verticalCenters)) / sectionRect.height
+            : 0,
+      }
+    }),
+  )
+
+  expect(layouts).toHaveLength(2)
+  for (const layout of layouts) {
+    expect(layout.stickerCount).toBe(8)
+    expect(layout.allInOuterGutters).toBe(true)
+    expect(layout.verticalCoverage).toBeGreaterThan(0.75)
+  }
+})
+
+test("gives work history more top breathing room without disconnecting it from about", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 })
+  await page.goto("/#about-panel")
+
+  const gap = await page.evaluate(() => {
+    const closing = document.querySelector(".mosaic-about-closing")
+    const heading = document.querySelector("#about-work-history-heading")
+    if (!closing || !heading) return Number.POSITIVE_INFINITY
+    return Math.round(heading.getBoundingClientRect().top - closing.getBoundingClientRect().bottom)
+  })
+
+  expect(gap).toBeGreaterThanOrEqual(72)
+  expect(gap).toBeLessThanOrEqual(80)
+})
+
+test("left aligns the work-history reading hierarchy", async ({ page }) => {
+  await page.goto("/#about-panel-resume")
+
+  const alignment = await page.locator("#about-panel-resume").evaluate((section) => {
+    const heading = section.querySelector("#about-work-history-heading")
+    const company = section.querySelector(".mosaic-about-resume-company")
+    return {
+      section: getComputedStyle(section).textAlign,
+      heading: heading ? getComputedStyle(heading).textAlign : null,
+      companyJustification: company ? getComputedStyle(company).justifyContent : null,
+    }
+  })
+
+  expect(alignment).toEqual({ section: "left", heading: "left", companyJustification: "flex-start" })
+})
+
+test("reveals company logo tooltips on hover and keyboard focus", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 })
+  await page.goto("/#about-panel-resume")
+
+  const trigger = page.getByRole("button", { name: "Show 0x Project logos" })
+  const tooltip = page.getByRole("tooltip", { name: "0x Project logos" })
+
+  await expect(tooltip).toBeHidden()
+  await trigger.hover()
+  await expect(tooltip).toBeVisible()
+  await page.mouse.move(0, 0)
+  await expect(tooltip).toBeHidden()
+  await trigger.focus()
+  await expect(tooltip).toBeVisible()
+  await expect(tooltip.locator("img")).toHaveCount(2)
+})
+
+test("keeps each employer as the accessible work-history heading", async ({ page }) => {
+  await page.goto("/#about-panel-resume")
+
+  await expect(page.getByRole("heading", { name: "0x Project", exact: true })).toBeVisible()
+  await expect(page.getByRole("button", { name: "Show 0x Project logos" })).toBeVisible()
+})
+
+test("keeps focus on a company trigger when Escape dismisses its logo tooltip", async ({ page }) => {
+  await page.goto("/#about-panel-resume")
+
+  const trigger = page.getByRole("button", { name: "Show 0x Project logos" })
+  const tooltip = page.getByRole("tooltip", { name: "0x Project logos" })
+  await trigger.focus()
+  await expect(tooltip).toBeVisible()
+
+  await trigger.press("Escape")
+
+  await expect(tooltip).toBeHidden()
+  await expect(trigger).toBeFocused()
+})
+
+test("defers resume-only company logos until their tooltip opens", async ({ page }) => {
+  const boldVoiceLogoPath = "/logos/boldvoice.png"
+  const requestedLogoPaths: string[] = []
+  page.on("request", (request) => {
+    const path = new URL(request.url()).pathname
+    if (path.startsWith("/logos/")) requestedLogoPaths.push(path)
+  })
+
   await page.goto("/")
+  await page.waitForLoadState("networkidle")
+  expect(requestedLogoPaths).not.toContain(boldVoiceLogoPath)
 
-  const tabs = page.getByRole("tablist", { name: "About me or work history" })
-  const indicator = tabs.locator(".mosaic-about-tab-indicator")
-
-  await expect(indicator).toHaveCount(1)
-  const aboutPosition = await indicator.boundingBox()
-  expect(aboutPosition).not.toBeNull()
-
-  await tabs.getByRole("tab", { name: "Work history" }).click()
-  await expect(tabs).toHaveAttribute("data-active-tab", "resume")
-  await expect
-    .poll(async () => (await indicator.boundingBox())?.x)
-    .toBeGreaterThan(aboutPosition?.x ?? 0)
+  const request = page.waitForRequest((candidate) => new URL(candidate.url()).pathname === boldVoiceLogoPath)
+  await page.getByRole("button", { name: "Show BoldVoice logos" }).focus()
+  await request
 })
 
-test("records the selected about tab in the URL", async ({ page }) => {
-  await page.emulateMedia({ reducedMotion: "reduce" })
-  await page.goto("/")
-
-  await page.locator("#about-panel").getByRole("tab", { name: "Work history" }).click()
-
-  await expect(page).toHaveURL(/#about-panel-resume$/)
-  await expect(page.getByRole("tab", { name: "Work history" })).toHaveAttribute("aria-selected", "true")
-})
-
-test("opens the resume tab from its deep link", async ({ page }) => {
+test("opens work history directly from its deep link", async ({ page }) => {
   await page.emulateMedia({ reducedMotion: "reduce" })
   await page.goto("/#about-panel-resume")
 
-  await expect(page.getByRole("tab", { name: "Work history" })).toHaveAttribute("aria-selected", "true")
-  await expect(page.locator("#about-panel")).toBeInViewport()
-})
-
-test("restores the about tab when navigating back from resume", async ({ page }) => {
-  await page.emulateMedia({ reducedMotion: "reduce" })
-  await page.goto("/")
-  await page.locator("#about-panel").getByRole("tab", { name: "Work history" }).click()
-
-  await page.goBack()
-
-  await expect(page).toHaveURL(/\/$/)
-  await expect(page.getByRole("tab", { name: "about me" })).toHaveAttribute("aria-selected", "true")
+  await expect(page).toHaveURL(/#about-panel-resume$/)
+  await expect(page.locator("#about-panel-resume")).toBeInViewport()
+  await expect(page.getByRole("heading", { name: "Work history" })).toBeVisible()
 })
 
 test("lets keyboard users move and reset about stickers", async ({ page }) => {
@@ -1329,7 +1631,7 @@ test("keeps desktop gallery navigation fixed near the modal top", async ({ page 
 
   await next.click()
   await next.click()
-  await expect(dialog.locator(".preview-gallery-count")).toHaveText("3 / 8")
+  await expect(dialog.locator(".preview-gallery-count")).toHaveText("3 / 12")
 
   const changedDialogBox = await dialog.boundingBox()
   const changedRailBox = await rail.boundingBox()
@@ -1340,7 +1642,7 @@ test("keeps desktop gallery navigation fixed near the modal top", async ({ page 
   expect(changedRailBox!.y).toBeCloseTo(initialRailBox!.y, 0)
 
   await previous.click()
-  await expect(dialog.locator(".preview-gallery-count")).toHaveText("2 / 8")
+  await expect(dialog.locator(".preview-gallery-count")).toHaveText("2 / 12")
 })
 
 test("does not use dots to navigate between projects in the main feed", async ({ page }) => {


### PR DESCRIPTION
Reworks the About area into a full-bleed scroll takeover with a continuous, deep-linkable work-history section, movable sticker sets, and accessible on-demand company-logo tooltips.

Adds a fourth portfolio row with four Matcha projects and updates the CV with the current founder role.

Updates the design-system documentation and expands Playwright coverage for takeover geometry, reduced motion, responsive flow, portfolio counts, résumé accessibility, focus retention, and deferred media loading.

Verified with lint, production build, 128 end-to-end tests, and 4 design-system tests.