### PR TITLE
Refine About and work history presentation

### DIFF
--- a/src/components/AboutPanel.tsx
+++ b/src/components/AboutPanel.tsx
@@ -1,7 +1,6 @@
 import {
   useCallback,
   useEffect,
-  useId,
   useRef,
   useState,
   type CSSProperties,
@@ -38,25 +37,14 @@ type AboutSticker = {
  * movement, and they are hidden below 900px where the panel has no spare room.
  */
 const aboutStickers: AboutSticker[] = [
-  { emoji: "🌴", label: "Palm tree", top: "6%", left: "2%", rotate: -12 },
+  { emoji: "🌴", label: "Palm tree", top: "5%", left: "2%", rotate: -12 },
   { emoji: "🎨", label: "Artist palette", top: "34%", left: "5%", rotate: 15 },
   { emoji: "✏️", label: "Pencil", bottom: "34%", left: "2%", rotate: 14 },
-  { emoji: "🌊", label: "Ocean wave", bottom: "6%", left: "5%", rotate: -9 },
+  { emoji: "🌊", label: "Ocean wave", bottom: "5%", left: "5%", rotate: -9 },
   { emoji: "🗽", label: "Statue of Liberty", top: "10%", right: "4%", rotate: 9 },
   { emoji: "💻", label: "Laptop", top: "38%", right: "2%", rotate: -6 },
   { emoji: "🤖", label: "Robot", bottom: "30%", right: "5%", rotate: 11 },
   { emoji: "🛠️", label: "Tools", bottom: "8%", right: "2%", rotate: -7 },
-]
-
-const resumeStickers: AboutSticker[] = [
-  { emoji: "🎓", label: "Graduation cap", top: "8%", left: "4%", rotate: 10 },
-  { emoji: "🖋️", label: "Fountain pen", top: "36%", left: "2%", rotate: -14 },
-  { emoji: "☕", label: "Coffee", bottom: "32%", left: "5%", rotate: 9 },
-  { emoji: "🚀", label: "Rocket", bottom: "6%", left: "2%", rotate: -11 },
-  { emoji: "💼", label: "Briefcase", top: "12%", right: "2%", rotate: -8 },
-  { emoji: "📈", label: "Chart trending up", top: "40%", right: "5%", rotate: 12 },
-  { emoji: "💡", label: "Light bulb", bottom: "28%", right: "2%", rotate: -6 },
-  { emoji: "🏆", label: "Trophy", bottom: "8%", right: "4%", rotate: 7 },
 ]
 
 type Offset = { x: number; y: number }
@@ -246,25 +234,15 @@ const hobbies = [
   { emoji: "🥋", label: "Jiu jitsu", learning: true },
 ]
 
-const elsewhereLinks = (links: SiteLinks) => [
-  { name: "X", href: links.x },
-  { name: "GitHub", href: links.github },
-  { name: "LinkedIn", href: links.linkedin },
-  { name: "Dribbble", href: links.dribbble },
-]
-
-function ResumeCompanyTooltip({ company, logoUrls }: { company: string; logoUrls: string[] }) {
-  const tooltipId = useId()
+function ResumeCompanyLink({ company, href, logoUrls }: { company: string; href: string; logoUrls: string[] }) {
   const [open, setOpen] = useState(false)
 
   return (
-    <button
-      type="button"
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
       className="mosaic-company-inline-link mosaic-about-resume-company-trigger"
-      aria-label={`Show ${company} logos`}
-      aria-describedby={open ? tooltipId : undefined}
-      aria-expanded={open}
-      onClick={() => setOpen(true)}
       onFocus={() => setOpen(true)}
       onBlur={() => setOpen(false)}
       onPointerEnter={() => {
@@ -274,16 +252,12 @@ function ResumeCompanyTooltip({ company, logoUrls }: { company: string; logoUrls
         if (document.activeElement !== event.currentTarget) setOpen(false)
       }}
       onKeyDown={(event) => {
-        if (event.key !== "Escape") return
-        setOpen(false)
+        if (event.key === "Escape") setOpen(false)
       }}
     >
       <span className="mosaic-company-inline-name">{company}</span>
       <span
-        id={tooltipId}
-        role="tooltip"
-        aria-label={`${company} logos`}
-        aria-hidden={open ? undefined : true}
+        aria-hidden="true"
         className="mosaic-company-inline-hover-logos"
         data-open={open ? "true" : "false"}
       >
@@ -301,7 +275,7 @@ function ResumeCompanyTooltip({ company, logoUrls }: { company: string; logoUrls
             ))
           : null}
       </span>
-    </button>
+    </a>
   )
 }
 
@@ -361,18 +335,13 @@ export function AboutPanel({ links }: AboutPanelProps) {
             aria-labelledby="about-section-heading"
           >
             <div className="mosaic-about-section-copy">
-              <h2 id="about-section-heading" className="sr-only">
+              <h2 id="about-section-heading" className="mosaic-about-lede">
                 About me
               </h2>
-              <p className="mosaic-about-lede">Hi, I&rsquo;m Rafael.</p>
               <p>
-                I&rsquo;ve spent the last ten years designing products, mostly the complicated parts people
-                prefer not to think about. I figure out what to build, test it with real people, and stay
-                for the fixes after launch.
-              </p>
-              <p>
-                I prototype in code. A working interaction answers questions faster than a static mockup,
-                and usually faster than a meeting.
+                I design the complicated parts of products people prefer not to think about. I figure out
+                what to build, test it with real people, and prototype in code because working interactions
+                answer questions faster than static mockups.
               </p>
               <p>
                 When I&rsquo;m not working, I&rsquo;m probably kickboxing, swimming, riding a bike, or being humbled
@@ -392,42 +361,6 @@ export function AboutPanel({ links }: AboutPanelProps) {
                   </li>
                 ))}
               </ul>
-
-              <dl className="mosaic-about-facts">
-                <div className="mosaic-about-fact">
-                  <dt>Now</dt>
-                  <dd>Freelance, splitting time between Punta Cana and NYC.</dd>
-                </div>
-                <div className="mosaic-about-fact">
-                  <dt>Lately</dt>
-                  <dd>Prototypes, AI tooling, and design systems.</dd>
-                </div>
-                <div className="mosaic-about-fact">
-                  <dt>Elsewhere</dt>
-                  <dd>
-                    {elsewhereLinks(links).map((link, index) => (
-                      <span key={link.name}>
-                        {index > 0 ? <span aria-hidden="true"> · </span> : null}
-                        <a
-                          href={link.href}
-                          target="_blank"
-                          rel="noreferrer"
-                          className="mosaic-about-link"
-                          onClick={() => {
-                            trackEvent("social_link_click", {
-                              social_label: link.name,
-                              social_href: link.href,
-                              social_placement: "about_panel",
-                            })
-                          }}
-                        >
-                          {link.name}
-                        </a>
-                      </span>
-                    ))}
-                  </dd>
-                </div>
-              </dl>
 
               <p className="mosaic-about-closing">
                 Taking on new work. Building something?{" "}
@@ -459,58 +392,78 @@ export function AboutPanel({ links }: AboutPanelProps) {
             aria-labelledby="about-work-history-heading"
           >
             <div className="mosaic-about-work-history-copy">
-              <h2 id="about-work-history-heading" className="mosaic-about-section-heading">
-                Work history
-              </h2>
-              <p className="mosaic-about-lede">Senior Product Designer.</p>
-              <p>
-                Ten years across web3, fintech, and consumer products — from early strategy to
-                shipped interfaces.
-              </p>
-              <ol className="mosaic-about-resume">
+              <div className="mosaic-about-section-heading-row">
+                <h2 id="about-work-history-heading" className="mosaic-about-section-heading">
+                  Work history
+                </h2>
+                <a
+                  href={links.resumePdf}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="mosaic-about-link mosaic-about-resume-link"
+                  onClick={() => {
+                    trackEvent("social_link_click", {
+                      social_label: "Download Resume",
+                      social_href: links.resumePdf,
+                      social_placement: "about_panel",
+                    })
+                  }}
+                >
+                  Full résumé
+                </a>
+              </div>
+              <ol className="mosaic-about-resume mosaic-about-work-list">
                 {cvExperience.map((job) => (
-                  <li key={`${job.company}-${job.dates}`} className="mosaic-about-resume-entry">
-                    <h3
-                      className="mosaic-about-resume-company"
-                      aria-label={job.logoUrls ? job.company : undefined}
-                    >
-                      {job.logoUrls ? (
-                        <ResumeCompanyTooltip company={job.company} logoUrls={job.logoUrls} />
-                      ) : (
-                        job.company
-                      )}
-                    </h3>
-                    <p className="mosaic-about-resume-meta">
-                      {job.role} <span aria-hidden="true">·</span> {job.dates}
-                    </p>
-                    <ul className="mosaic-about-resume-highlights">
-                      {job.achievements.map((achievement) => (
-                        <li key={achievement}>{achievement}</li>
-                      ))}
-                    </ul>
+                  <li
+                    key={`${job.company}-${job.dates}`}
+                    className="mosaic-about-resume-entry mosaic-about-work-entry"
+                  >
+                    <p className="mosaic-about-resume-dates">{job.dates}</p>
+                    <div className="mosaic-about-resume-details">
+                      <h3
+                        className="mosaic-about-resume-title"
+                        aria-label={`${job.role} at ${job.company}`}
+                      >
+                        {job.role} at{" "}
+                        {job.href && job.logoUrls ? (
+                          <ResumeCompanyLink company={job.company} href={job.href} logoUrls={job.logoUrls} />
+                        ) : (
+                          <span>{job.company}</span>
+                        )}
+                      </h3>
+                      <p className="mosaic-about-resume-location">{job.location}</p>
+                      <p className="mosaic-about-resume-description">{job.highlight}</p>
+                    </div>
                   </li>
                 ))}
               </ol>
 
               <div className="mosaic-about-resume-education">
                 <h3 className="mosaic-about-resume-heading">Education</h3>
-                <ul className="mosaic-about-resume">
+                <ul className="mosaic-about-resume mosaic-about-education-list">
                   {cvEducation.map((school) => (
-                    <li key={school.school} className="mosaic-about-resume-entry">
-                      <h4 className="mosaic-about-resume-company">{school.school}</h4>
-                      <p className="mosaic-about-resume-meta">
-                        {school.credential} <span aria-hidden="true">·</span> {school.location}
-                      </p>
-                      {school.details ? (
-                        <p className="mosaic-about-resume-note">{school.details}</p>
-                      ) : null}
+                    <li
+                      key={school.school}
+                      className="mosaic-about-resume-entry mosaic-about-work-entry"
+                    >
+                      <p className="mosaic-about-resume-dates">{school.dates}</p>
+                      <div className="mosaic-about-resume-details">
+                        <h4
+                          className="mosaic-about-resume-title"
+                          aria-label={`${school.credential} at ${school.school}`}
+                        >
+                          {school.credential} at <span>{school.school}</span>
+                        </h4>
+                        <p className="mosaic-about-resume-location">{school.location}</p>
+                        {school.details ? (
+                          <p className="mosaic-about-resume-description">{school.details}</p>
+                        ) : null}
+                      </div>
                     </li>
                   ))}
                 </ul>
               </div>
             </div>
-
-            {renderStickers(resumeStickers)}
           </section>
         </div>
       </div>

--- a/src/components/DesignSystemPage.tsx
+++ b/src/components/DesignSystemPage.tsx
@@ -144,7 +144,7 @@ const INK = [
   { hex: "#171717", token: "—", use: "Text inside white cards and the preview dialog" },
   { hex: "#2d2d2d", token: "--focus-ring", use: "Primary UI labels, hover states, and every focus ring" },
   { hex: "#4a4a4a", token: "—", use: "Inline links at rest" },
-  { hex: "#545454", token: "—", use: "About-panel prose and résumé highlights" },
+  { hex: "#545454", token: "—", use: "About-panel prose" },
   { hex: "#6b6b6b", token: "--muted", use: "Secondary copy: subtitles, captions, dialog descriptions" },
   { hex: "#747474", token: "—", use: "Corner nav links and the local-time label" },
   { hex: "#757575", token: "--muted-soft", use: "Tertiary labels: definition terms, hobby notes, headings" },
@@ -205,7 +205,7 @@ const TYPE_SCALE = [
     token: "--text-md",
     sample: "Senior Product Designer",
     spec: "1rem · 16px",
-    where: "Hero name; About prose, labels, section headings, résumé companies, and metadata",
+    where: "Hero name; About prose, labels, section headings, card titles, and metadata",
     style: { fontSize: "var(--text-md)", lineHeight: 1.5, letterSpacing: "-0.005rem", fontWeight: 600 },
   },
   {
@@ -218,9 +218,9 @@ const TYPE_SCALE = [
 ]
 
 const WEIGHTS = [
-  { value: 400, use: "Body copy, nav links, summaries, definition values" },
+  { value: 400, use: "Body copy, nav links, summaries, definition values, résumé titles and companies" },
   { value: 500, use: "Pill labels, preview titles, popover roles" },
-  { value: 600, use: "Headings, card titles, résumé companies, the mobile reveal, the X follow button" },
+  { value: 600, use: "Headings, card titles, the mobile reveal, the X follow button" },
   { value: 700, use: "The X card name and stats only — vendor weight" },
 ]
 
@@ -250,11 +250,14 @@ const SPACE = [
   { value: "0.375rem", use: "Inside pills and stat groups" },
   { value: "0.5rem", use: "Hobby lists, X card internals" },
   { value: "0.625rem", use: "The contact action row" },
+  { value: "0.75rem", use: "Work-history description offset and compact floating offsets" },
   { value: "1.25rem", use: "Maximum mobile contact-pill side padding" },
+  { value: "5rem", use: "Mobile whitespace between About and Work history" },
+  { value: "8.75rem", use: "Desktop whitespace between About and Work history" },
   { value: "8px", use: "Mobile page gutter and row-video side inset below 700px" },
   { value: "1rem", use: "Mosaic row and column gap — the layout unit" },
   { value: "clamp(16px, 3vw, 32px)", use: "Page gutter from 700px to 899px" },
-  { value: "clamp(8rem, 20vh, 12rem)", use: "Desktop white runway before the About takeover" },
+  { value: "clamp(12rem, 30vh, 18rem)", use: "Desktop white runway before the About takeover" },
 ]
 
 /* --------------------------------------------------------------- elevation */
@@ -273,7 +276,7 @@ const ELEVATION = [
   {
     name: "Hover card",
     shadow: "0 1px 2px rgb(16 16 20 / 0.06), 0 12px 32px rgb(16 16 20 / 0.16)",
-    use: "LinkedIn and X cards, the work-history popover. A tight contact shadow plus one wide ambient.",
+    use: "LinkedIn and X cards, the work-history popover, and the About takeover. A tight contact shadow plus one wide ambient.",
   },
   {
     name: "Dialog",
@@ -1116,19 +1119,22 @@ export function DesignSystemPage({ links, name }: DesignSystemPageProps) {
                 <li>
                   <strong>The About takeover is one viewport of scrolling.</strong> From 700px up, all four project rows
                   remain in one sticky stage at their original sizes and 1rem gaps, followed by a responsive white
-                  runway of <code>clamp(8rem, 20vh, 12rem)</code>.
+                  runway of <code>clamp(12rem, 30vh, 18rem)</code>.
                   The runway is the gallery's natural height plus <code>100dvh</code>; the gallery pins when its bottom reaches the viewport, then the
-                  full-bleed white About sheet crosses it at z-index 1. The gallery retreats as one surface, and About
+                  full-bleed white About sheet crosses it at z-index 1 with the same layered shadow as the hover cards. The gallery retreats as one surface, and About
                   continues in normal flow after the cover. Below 700px both wrappers collapse with{" "}
                   <code>display: contents</code>; the white sheet stays full-bleed but no pinning or overlap is applied.
                 </li>
                 <li>
                   <strong>About is one continuous reading surface.</strong> The introduction, Work history, and Education
-                  share one left-aligned 34rem reading axis in normal document flow. A content-width hairline separates
-                  About from Work history, with 3rem of space before the heading. Both eight-sticker sets span four
-                  vertical bands inside the outer 8% of the desktop side gutters. Work-history company names reveal
-                  their logo tooltips on hover, focus, and touch. There is no tab state or hidden panel; <code>#about-panel-resume</code> anchors
-                  directly to the visible Work history section.
+                  share one left-aligned 36rem reading axis in normal document flow. Work history sits 8.75rem (140px)
+                  below About on desktop and 5rem (80px) below it on mobile, without a hairline. About&rsquo;s eight stickers span four
+                  vertical bands inside the outer 8% of the desktop side gutters; Work history stays undecorated so
+                  its compact role rows remain easy to scan. Each role shows one representative result, aligns its
+                  dates opposite the company on wider screens, and points to the full résumé for the complete detail.
+                  Company names are keyboard-focusable external links that reveal non-interactive logo tooltips on
+                  hover and focus. There is no tab state or
+                  hidden panel; <code>#about-panel-resume</code> anchors directly to the visible Work history section.
                 </li>
               </ul>
             </div>

--- a/src/data/cv.ts
+++ b/src/data/cv.ts
@@ -3,81 +3,75 @@ export type CvExperience = {
   location: string
   dates: string
   role: string
-  achievements: string[]
-  /** Small logo coins shown beside the company name. */
+  highlight: string
+  /** Primary company link and decorative logo tooltip. */
+  href?: string
   logoUrls?: string[]
 }
 
 export type CvEducation = {
   school: string
   location: string
+  dates: string
   credential: string
   details?: string
 }
 
 export const cvExperience: CvExperience[] = [
   {
-    company: "Stealth",
+    company: "Startup",
     location: "Remote",
-    dates: "Mar 2026 - Present",
-    role: "Founder",
-    achievements: ["Building a mobile wallet product."],
+    dates: "2026 - Present",
+    role: "Co-founder",
+    highlight:
+      "Building a mobile wallet for colmados, helping neighborhood store owners in the Dominican Republic manage payments and day-to-day finances from their phones.",
   },
   {
     company: "0x Project",
     location: "Remote, SF",
-    dates: "Dec 2021 - Mar 2026",
+    dates: "2021 - 2026",
     role: "Senior Product Designer",
+    href: "https://0x.org/",
     logoUrls: ["/logos/0x.png", "/logos/matcha.svg"],
-    achievements: [
-      "Redesigned Matcha.xyz from scratch and introduced monetization flows that generated sustainable revenue.",
-      "Designed and shipped the 0x API dashboard in five weeks, contributing to API revenue scaling beyond $100K per month.",
-      "Led marketing design strategy for 12 months across campaigns, video content, and web experiences that increased developer adoption.",
-    ],
+    highlight: "Redesigned Matcha.xyz from scratch and introduced monetization flows that generated sustainable revenue.",
   },
   {
     company: "BoldVoice",
     location: "Remote, NYC",
-    dates: "Jul 2021 - Dec 2021",
+    dates: "2021",
     role: "Product Designer (Contract)",
+    href: "https://boldvoice.com/",
     logoUrls: ["/logos/boldvoice.png"],
-    achievements: [
+    highlight:
       "Sole designer for an accent-training mobile app with more than 50K users, partnering directly with one developer to ship growth experiments.",
-      "Prioritized high-ROI product improvements over a full redesign to maximize impact with limited resources.",
-    ],
   },
   {
     company: "Moody's",
     location: "Remote, NYC",
-    dates: "Jan 2021 - Jul 2021",
+    dates: "2021",
     role: "Product Designer (Contract)",
+    href: "https://www.moodys.com/",
     logoUrls: ["/logos/moodys.png"],
-    achievements: [
-      "Redesigned financial-analysis tools for institutional analysts, improving data discovery and workflow efficiency.",
-      "Shaped UX for company profiles and government-entity features used by thousands of financial professionals.",
-    ],
+    highlight: "Redesigned financial-analysis tools for institutional analysts, improving data discovery and workflow efficiency.",
   },
   {
     company: "TM (Chainlink, Twilio, and Onit)",
     location: "Remote, Los Angeles",
-    dates: "Dec 2018 - Dec 2020",
+    dates: "2018 - 2020",
     role: "Product Designer & Frontend Developer",
+    href: "https://chain.link/",
     logoUrls: ["/logos/chainlink.svg", "/logos/twilio.svg", "/logos/onit.png"],
-    achievements: [
-      "Chainlink: collaborated on internal tools and the brand system for a leading blockchain oracle network.",
-      "Twilio: led a redesign of the developer-tools platform, supported by user interviews and UX research.",
-      "Onit: rebuilt a drag-and-drop logic builder with React for legal workflow automation.",
-    ],
+    highlight:
+      "Chainlink: collaborated on internal product tools and the brand system, helping make a complex blockchain oracle network clearer and more consistent as the company scaled.",
   },
   {
     company: "Incubeta (Google)",
     location: "Remote, NYC",
-    dates: "Jan 2018 - May 2018",
+    dates: "2018",
     role: "Product Designer & Developer (Contract)",
+    href: "https://www.google.com/",
     logoUrls: ["/logos/Google_logo.svg"],
-    achievements: [
-      "Designed Google Edu Directory, connecting schools globally with certified Google trainers.",
-    ],
+    highlight: "Designed Google Edu Directory, connecting schools globally with certified Google trainers.",
   },
 ]
 
@@ -85,12 +79,15 @@ export const cvEducation: CvEducation[] = [
   {
     school: "CCI Program - NOVA Community College",
     location: "Washington, DC",
-    credential: "Computer Science, 2016 - 2018",
+    dates: "2016 - 2018",
+    credential: "Computer Science",
     details: "U.S. State Department scholarship recipient (1 of 5 from the Dominican Republic).",
   },
   {
     school: "ITLA - Las Americas Institute of Technology",
     location: "Dominican Republic",
-    credential: "Associate's, Computer Science, 2015 - GPA 3.8, Full Scholarship",
+    dates: "2015",
+    credential: "Associate's, Computer Science",
+    details: "GPA 3.8, Full Scholarship.",
   },
 ]

--- a/src/data/portfolio.ts
+++ b/src/data/portfolio.ts
@@ -96,7 +96,6 @@ export const homeRows: HomeRow[] = [
     height: homeTileRowHeight,
     items: [
       { cardId: "preview-shot-14", span: 1 },
-      { cardId: "preview-shot-15", span: 1 },
       { cardId: "preview-shot-23", span: 1 },
       { cardId: "preview-shot-20", span: 1 },
     ],

--- a/src/index.css
+++ b/src/index.css
@@ -866,7 +866,7 @@ img {
 }
 
 .mosaic-about-section-copy {
-  width: min(100%, 34rem);
+  width: min(100%, 36rem);
   margin-inline: auto;
   display: grid;
   gap: 1.05rem;
@@ -876,23 +876,35 @@ img {
 .mosaic-about-work-history {
   position: relative;
   width: 100%;
-  padding-block: 1.5rem clamp(2rem, 6vw, 5rem);
+  margin-block-start: 5rem;
+  padding-block: 0 clamp(2rem, 6vw, 5rem);
   scroll-margin-top: clamp(1rem, 4vw, 3rem);
   text-align: left;
 }
 
+@media (min-width: 700px) {
+  .mosaic-about-work-history {
+    margin-block-start: 8.75rem;
+  }
+}
+
 .mosaic-about-work-history-copy {
-  width: min(100%, 34rem);
+  width: min(100%, 36rem);
   margin-inline: auto;
-  border-top: 1px solid rgb(0 0 0 / 0.08);
-  padding-top: 3rem;
   display: grid;
-  gap: 1.05rem;
+  gap: 1rem;
   text-align: left;
 }
 
+.mosaic-about-section-heading-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
 .mosaic-about-section-heading {
-  margin: 0 0 clamp(0.75rem, 2vw, 1.5rem);
+  margin: 0;
   color: var(--muted-soft);
   font-size: var(--text-md);
   font-weight: 400;
@@ -911,6 +923,7 @@ img {
 }
 
 .mosaic-about-body .mosaic-about-lede {
+  margin: 0;
   font-size: var(--text-lg);
   font-weight: 600;
   line-height: 1.5;
@@ -919,7 +932,7 @@ img {
 }
 
 .mosaic-about-hobbies {
-  margin: 0 0 0.9rem;
+  margin: 0.5rem 0 0.9rem;
   padding: 0;
   list-style: none;
   display: flex;
@@ -947,38 +960,6 @@ img {
   color: var(--muted-soft);
 }
 
-.mosaic-about-facts {
-  margin: 0.5rem 0 0;
-  display: grid;
-  gap: 0.75rem;
-  border-top: 1px solid rgb(0 0 0 / 0.08);
-  padding-top: 1.25rem;
-}
-
-.mosaic-about-fact {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-start;
-  align-items: baseline;
-  gap: 0.25rem 0.5rem;
-}
-
-.mosaic-about-fact dt {
-  margin: 0;
-  font-size: var(--text-md);
-  line-height: 1.6;
-  letter-spacing: -0.005rem;
-  color: var(--muted-soft);
-}
-
-.mosaic-about-fact dd {
-  margin: 0;
-  font-size: var(--text-md);
-  line-height: 1.6;
-  letter-spacing: -0.005rem;
-  color: #2d2d2d;
-}
-
 .mosaic-about-link {
   color: #2d2d2d;
   text-decoration-line: underline;
@@ -993,94 +974,97 @@ img {
   text-decoration-color: #2d2d2d;
 }
 
-.mosaic-about-fact dd > span > span[aria-hidden="true"] {
-  color: #c0c0c0;
-}
-
 .mosaic-about-closing {
   border-top: 1px solid rgb(0 0 0 / 0.08);
   padding-top: 1.25rem;
 }
 
+.mosaic-about-resume-link {
+  flex: none;
+  font-size: var(--text-md);
+  line-height: 1.6;
+}
+
 .mosaic-about-resume {
-  margin: 0.35rem 0 0;
+  margin: 0.25rem 0 0;
   padding: 0;
   list-style: none;
   display: grid;
-  gap: 1.6rem;
+  gap: 0;
+}
+
+.mosaic-about-work-list {
+  margin-top: 1.5rem;
+  gap: 3rem;
 }
 
 .mosaic-about-resume-entry {
   display: grid;
-  gap: 0.2rem;
+  gap: 0.35rem;
+  border-top: 1px solid rgb(0 0 0 / 0.08);
+  padding-block: 1.25rem;
 }
 
-.mosaic-about-body .mosaic-about-resume-company {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 0.5rem;
+.mosaic-about-resume > .mosaic-about-resume-entry:first-child {
+  border-top: 0;
+}
+
+.mosaic-about-work-entry {
+  display: grid;
+  grid-template-columns: 6.25rem minmax(0, 1fr);
+  align-items: start;
+  gap: 2rem;
+  border-top: 0;
+  padding-block: 0;
+}
+
+.mosaic-about-resume-details {
+  min-width: 0;
+}
+
+.mosaic-about-body .mosaic-about-resume-title {
+  margin: 0;
   font-size: var(--text-md);
-  font-weight: 600;
+  font-weight: 400;
   line-height: 1.5;
   letter-spacing: -0.005rem;
   color: #2d2d2d;
+  text-wrap: balance;
 }
 
-.mosaic-about-resume-company-trigger {
-  appearance: none;
-  border: 0;
-  background: transparent;
-  padding: 0;
-  font: inherit;
-  text-align: left;
-  cursor: pointer;
-}
-
-.mosaic-about-resume-company-trigger .mosaic-company-inline-hover-logos[data-open="true"] {
-  opacity: 1;
-  visibility: visible;
-  transform:
-    perspective(920px)
-    translate(calc(-50% + var(--mosaic-hover-anchor-x)), var(--mosaic-hover-anchor-y))
-    rotateX(var(--mosaic-hover-tilt-x))
-    rotateY(var(--mosaic-hover-tilt-y))
-    scale(var(--mosaic-hover-lift));
-}
-
-.mosaic-about-body .mosaic-about-resume-meta {
+.mosaic-about-body .mosaic-about-resume-location {
+  margin-top: 0.1rem;
   font-size: var(--text-md);
   line-height: 1.5;
   color: var(--muted);
 }
 
-.mosaic-about-body .mosaic-about-resume-highlights {
-  margin: 0.4rem 0 0;
-  padding: 0;
-  list-style: none;
-  display: grid;
-  gap: 0.35rem;
+.mosaic-about-body .mosaic-about-resume-dates {
+  font-size: var(--text-md);
+  line-height: 1.5;
+  color: var(--muted-soft);
+  white-space: nowrap;
 }
 
-.mosaic-about-body .mosaic-about-resume-highlights li {
+.mosaic-about-body .mosaic-about-resume-description {
+  margin-top: 0.75rem;
   font-size: var(--text-md);
   line-height: 1.6;
   letter-spacing: -0.005rem;
-  color: #545454;
+  color: var(--muted);
   text-wrap: pretty;
 }
 
 .mosaic-about-resume-education {
-  margin-top: 0.5rem;
-  border-top: 1px solid rgb(0 0 0 / 0.08);
-  padding-top: 1.25rem;
+  margin-top: 4rem;
+  padding-top: 0;
   display: grid;
-  gap: 1.05rem;
+  gap: 1.5rem;
 }
 
-.mosaic-about-resume-education .mosaic-about-resume {
+.mosaic-about-education-list {
   margin-top: 0;
+  gap: 3rem;
 }
 
 .mosaic-about-body .mosaic-about-resume-heading {
@@ -1090,11 +1074,19 @@ img {
   color: var(--muted-soft);
 }
 
-.mosaic-about-body .mosaic-about-resume-note {
-  font-size: var(--text-md);
-  line-height: 1.6;
-  color: #545454;
-  text-wrap: pretty;
+@media (max-width: 479.98px) {
+  .mosaic-about-work-list {
+    gap: 3rem;
+  }
+
+  .mosaic-about-work-entry {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.35rem;
+  }
+
+  .mosaic-about-body .mosaic-about-resume-dates {
+    white-space: normal;
+  }
 }
 
 .mosaic-profile-meta h2 {
@@ -1654,8 +1646,9 @@ img {
   backdrop-filter: blur(10px);
 }
 
-.mosaic-company-inline-link:hover .mosaic-company-inline-hover-logos,
-.mosaic-company-inline-link:focus-visible .mosaic-company-inline-hover-logos {
+.mosaic-company-inline-link:not(.mosaic-about-resume-company-trigger):hover .mosaic-company-inline-hover-logos,
+.mosaic-company-inline-link:not(.mosaic-about-resume-company-trigger):focus-visible .mosaic-company-inline-hover-logos,
+.mosaic-about-resume-company-trigger .mosaic-company-inline-hover-logos[data-open="true"] {
   opacity: 1;
   visibility: visible;
   transform:
@@ -2326,7 +2319,7 @@ img {
 
   .mosaic-takeover-runway {
     --takeover-row-height: clamp(180px, 16vw, 260px);
-    --takeover-breathing-room: clamp(8rem, 20vh, 12rem);
+    --takeover-breathing-room: clamp(12rem, 30vh, 18rem);
     --takeover-gallery-height: calc(
       var(--takeover-row-height) + var(--takeover-row-height) + var(--takeover-row-height) +
         var(--takeover-row-height) + 3rem + var(--takeover-breathing-room)
@@ -2357,6 +2350,9 @@ img {
   .mosaic-about {
     margin-top: -100vh;
     margin-top: -100dvh;
+    box-shadow:
+      0 1px 2px rgb(16 16 20 / 0.06),
+      0 12px 32px rgb(16 16 20 / 0.16);
     view-timeline-name: --about-takeover;
     view-timeline-axis: block;
   }

--- a/tests/design-system/design-system.spec.ts
+++ b/tests/design-system/design-system.spec.ts
@@ -52,6 +52,21 @@ test("documents the computed navigation hit area", async ({ page }) => {
   await expect(controlsCaption).toContainText(hitArea)
 })
 
+test("documents the computed resume-title weight", async ({ page }) => {
+  await page.goto("/#about-panel-resume")
+  const resumeTitleWeight = await page
+    .locator(".mosaic-about-resume-title")
+    .first()
+    .evaluate((title) => getComputedStyle(title).fontWeight)
+
+  await openDesignSystem(page)
+  const weightRow = page
+    .locator("#typography table tbody tr")
+    .filter({ has: page.getByRole("cell", { name: resumeTitleWeight, exact: true }) })
+
+  await expect(weightRow).toContainText("résumé titles and companies")
+})
+
 test("documents component-specific motion curves that still ship", async ({ page }) => {
   await page.goto("/")
 

--- a/tests/e2e/portfolio-polish.spec.ts
+++ b/tests/e2e/portfolio-polish.spec.ts
@@ -175,15 +175,13 @@ test("uses only the body and lead type steps throughout About", async ({ page })
     "#about-section .mosaic-about-lede",
     "#about-section .mosaic-about-section-copy > p:not(.mosaic-about-lede)",
     "#about-section .mosaic-about-hobbies li",
-    "#about-section .mosaic-about-fact dt",
-    "#about-section .mosaic-about-fact dd",
     ".mosaic-about-section-heading",
-    ".mosaic-about-work-history-copy > .mosaic-about-lede",
-    ".mosaic-about-resume-company",
-    ".mosaic-about-resume-meta",
-    ".mosaic-about-resume-highlights li",
+    ".mosaic-about-resume-link",
+    ".mosaic-about-resume-title",
+    ".mosaic-about-resume-dates",
+    ".mosaic-about-resume-location",
+    ".mosaic-about-resume-description",
     ".mosaic-about-resume-heading",
-    ".mosaic-about-resume-note",
   ].join(", "))
   const sizes = await typeRoles.evaluateAll((elements) =>
     [...new Set(elements.map((element) => getComputedStyle(element).fontSize))].sort(),
@@ -191,7 +189,13 @@ test("uses only the body and lead type steps throughout About", async ({ page })
 
   expect(sizes).toEqual(["16px", "18px"])
   await expect(page.locator(".mosaic-about-section-heading")).toHaveCSS("font-size", "16px")
-  await expect(page.locator(".mosaic-about-work-history-copy > .mosaic-about-lede")).toHaveCSS("font-size", "18px")
+  await expect(page.locator("#about-section .mosaic-about-lede")).toHaveCSS("font-size", "18px")
+
+  const workHistorySizes = await page
+    .locator("#about-panel-resume")
+    .locator("h2, h3, h4, p, li, a")
+    .evaluateAll((elements) => [...new Set(elements.map((element) => getComputedStyle(element).fontSize))])
+  expect(workHistorySizes).toEqual(["16px"])
 })
 
 test("gives mobile contact actions generous horizontal padding", async ({ page }) => {
@@ -238,7 +242,9 @@ test("adds breathing room below the previous-work label on mobile", async ({ pag
   await page.goto("/")
 
   const previousWorkLabel = page.getByText("previously worked with and at", { exact: true })
-  const firstPreviousCompany = page.getByRole("link", { name: "Moody's", exact: true })
+  const firstPreviousCompany = page
+    .locator(".mosaic-work-history")
+    .getByRole("link", { name: "Moody's", exact: true })
   const [labelBox, companyBox] = await Promise.all([
     previousWorkLabel.boundingBox(),
     firstPreviousCompany.boundingBox(),
@@ -906,7 +912,7 @@ test("stacks about before work history without tab controls", async ({ page }) =
   const about = page.locator("#about-section")
   const workHistory = page.locator("#about-panel-resume")
   await expect(page.getByRole("tablist")).toHaveCount(0)
-  await expect(about.getByText(/Hi, I.m Rafael/)).toBeVisible()
+  await expect(about.locator(".mosaic-about-lede")).toBeVisible()
   await expect(workHistory.getByRole("heading", { name: "Work history" })).toBeVisible()
 
   const order = await page.locator("#about-section, #about-panel-resume").evaluateAll(([aboutNode, workNode]) => {
@@ -930,13 +936,11 @@ test("left aligns the about introduction with the work-history reading axis", as
       const aboutRect = aboutCopy.getBoundingClientRect()
       const workHistoryRect = workHistoryCopy.getBoundingClientRect()
       const hobbies = aboutCopy.querySelector(".mosaic-about-hobbies")
-      const fact = aboutCopy.querySelector(".mosaic-about-fact")
 
       return {
         sharedLeftEdge: Math.round(aboutRect.left) === Math.round(workHistoryRect.left),
         aboutTextAlign: getComputedStyle(aboutCopy).textAlign,
         hobbiesJustification: hobbies ? getComputedStyle(hobbies).justifyContent : null,
-        factsJustification: fact ? getComputedStyle(fact).justifyContent : null,
       }
     },
   )
@@ -945,31 +949,28 @@ test("left aligns the about introduction with the work-history reading axis", as
     sharedLeftEdge: true,
     aboutTextAlign: "left",
     hobbiesJustification: "flex-start",
-    factsJustification: "flex-start",
   })
 })
 
-test("separates work history from about with a content-width divider", async ({ page }) => {
+test("separates work history from about with 140px of desktop whitespace and no hairline", async ({ page }) => {
   await page.setViewportSize({ width: 1440, height: 900 })
   await page.goto("/")
 
-  const divider = await page.locator(".mosaic-about-work-history-copy").evaluate((element) => {
-    const styles = getComputedStyle(element)
+  const separation = await page.locator("#about-section, .mosaic-about-work-history-copy").evaluateAll(([about, workHistory]) => {
+    const styles = getComputedStyle(workHistory)
     return {
-      width: Math.round(element.getBoundingClientRect().width),
+      gap: Math.round(workHistory.getBoundingClientRect().top - about.getBoundingClientRect().bottom),
+      width: Math.round(workHistory.getBoundingClientRect().width),
       borderTopWidth: styles.borderTopWidth,
-      borderTopStyle: styles.borderTopStyle,
-      borderTopColor: styles.borderTopColor,
       paddingTop: styles.paddingTop,
     }
   })
 
-  expect(divider).toEqual({
-    width: 544,
-    borderTopWidth: "1px",
-    borderTopStyle: "solid",
-    borderTopColor: "rgba(0, 0, 0, 0.08)",
-    paddingTop: "48px",
+  expect(separation).toEqual({
+    gap: 140,
+    width: 576,
+    borderTopWidth: "0px",
+    paddingTop: "0px",
   })
 })
 
@@ -1023,7 +1024,7 @@ test("leaves a generous white runway after the final project row before the abou
     return Math.round(element.getBoundingClientRect().bottom - lastRow.getBoundingClientRect().bottom)
   })
 
-  expect(endSpacing).toBeGreaterThanOrEqual(160)
+  expect(endSpacing).toBeGreaterThanOrEqual(250)
 })
 
 test("pins the complete project grid when its bottom reaches the viewport", async ({ page }) => {
@@ -1073,6 +1074,21 @@ test("scrolls the about surface over the pinned project grid", async ({ page }) 
   })
 
   expect(placement).toEqual({ stageBottom: 913, aboutTop: 456, aboutOwnsCoveredArea: true })
+})
+
+test("reuses the hover-card shadow for the about takeover", async ({ page }) => {
+  await page.setViewportSize({ width: 1728, height: 913 })
+  await page.goto("/")
+
+  const about = page.locator("#about-panel")
+  const hoverCard = page.locator(".mosaic-linkedin-card")
+
+  const [aboutShadow, hoverCardShadow] = await Promise.all([
+    about.evaluate((element) => getComputedStyle(element).boxShadow),
+    hoverCard.evaluate((element) => getComputedStyle(element).boxShadow),
+  ])
+
+  expect(aboutShadow).toBe(hoverCardShadow)
 })
 
 test("retreats the complete project grid as one surface during takeover", async ({ page }) => {
@@ -1271,7 +1287,7 @@ test("keeps the restored third-row projects equal width", async ({ page }) => {
   expect(tradePageBox!.width).toBeCloseTo(tradeModuleBox!.width, 0)
 })
 
-test("adds four more projects in the fourth row", async ({ page }) => {
+test("caps each row at three projects and omits Mobile navigation", async ({ page }) => {
   await page.goto("/")
 
   const rows = page.locator(".mosaic-row")
@@ -1279,15 +1295,18 @@ test("adds four more projects in the fourth row", async ({ page }) => {
   const cards = lastRow.locator(".mosaic-row-card")
 
   await expect(rows).toHaveCount(4)
-  await expect(cards).toHaveCount(4)
+  const rowCardCounts = await rows.evaluateAll((elements) =>
+    elements.map((element) => element.querySelectorAll(".mosaic-row-card").length),
+  )
+  expect(rowCardCounts.every((count) => count <= 3)).toBe(true)
+  await expect(cards).toHaveCount(3)
   await expect(cards.nth(0)).toHaveAttribute("aria-label", /Open Matcha - Mobile Screens/)
-  await expect(cards.nth(1)).toHaveAttribute("aria-label", /Open Matcha - Mobile navigation/)
-  await expect(cards.nth(2)).toHaveAttribute("aria-label", /Open Matcha Pro/)
-  await expect(cards.nth(3)).toHaveAttribute("aria-label", /Open Matcha - Security Audit/)
+  await expect(cards.nth(1)).toHaveAttribute("aria-label", /Open Matcha Pro/)
+  await expect(cards.nth(2)).toHaveAttribute("aria-label", /Open Matcha - Security Audit/)
+  await expect(page.getByRole("button", { name: /Open Matcha - Mobile navigation/ })).toHaveCount(0)
   await expect(cards.nth(0).locator("img")).toHaveAttribute("src", /shot-small-14\.jpg$/)
-  await expect(cards.nth(1).locator("img")).toHaveAttribute("src", /shot-small-15\.jpg$/)
-  await expect(cards.nth(2).locator("img")).toHaveAttribute("src", /shot-small-23\.jpg$/)
-  await expect(cards.nth(3).locator("video")).toHaveAttribute("poster", "/Projects/shot-small-20-poster.webp")
+  await expect(cards.nth(1).locator("img")).toHaveAttribute("src", /shot-small-23\.jpg$/)
+  await expect(cards.nth(2).locator("video")).toHaveAttribute("poster", "/Projects/shot-small-20-poster.webp")
 })
 
 test("keeps the fourth-row projects equal width", async ({ page }) => {
@@ -1295,7 +1314,7 @@ test("keeps the fourth-row projects equal width", async ({ page }) => {
   await page.goto("/")
 
   const cards = page.locator(".mosaic-row").last().locator(".mosaic-row-card")
-  await expect(cards).toHaveCount(4)
+  await expect(cards).toHaveCount(3)
   const widths = await cards.evaluateAll((elements) =>
     elements.map((element) => Math.round(element.getBoundingClientRect().width)),
   )
@@ -1380,7 +1399,7 @@ test("keeps gallery controls inside the mobile viewport and exposes a close butt
       }),
     )
   })
-  await expect(dialog.getByText("2 / 12", { exact: true })).toBeVisible()
+  await expect(dialog.getByText("2 / 11", { exact: true })).toBeVisible()
 
   await dialog.getByRole("button", { name: "Close preview" }).click()
   await expect(dialog).toBeHidden()
@@ -1407,7 +1426,7 @@ test("treats a mostly vertical touch gesture as scrolling rather than gallery pa
     element.dispatchEvent(new TouchEvent("touchend", { bubbles: true, changedTouches: [end] }))
   })
 
-  await expect(page.locator(".preview-gallery-count")).toHaveText("1 / 12")
+  await expect(page.locator(".preview-gallery-count")).toHaveText("1 / 11")
   await context.close()
 })
 
@@ -1444,7 +1463,7 @@ test("clears a cancelled gallery gesture before accepting the next horizontal sw
     const staleEnd = new Touch({ identifier: 1, target: element, clientX: 160, clientY: 180 })
     element.dispatchEvent(new TouchEvent("touchend", { bubbles: true, changedTouches: [staleEnd] }))
   })
-  await expect(page.locator(".preview-gallery-count")).toHaveText("1 / 12")
+  await expect(page.locator(".preview-gallery-count")).toHaveText("1 / 11")
 
   await card.evaluate((element) => {
     const start = new Touch({ identifier: 2, target: element, clientX: 280, clientY: 180 })
@@ -1454,7 +1473,7 @@ test("clears a cancelled gallery gesture before accepting the next horizontal sw
     )
     element.dispatchEvent(new TouchEvent("touchend", { bubbles: true, changedTouches: [end] }))
   })
-  await expect(page.locator(".preview-gallery-count")).toHaveText("2 / 12")
+  await expect(page.locator(".preview-gallery-count")).toHaveText("2 / 11")
   await context.close()
 })
 
@@ -1498,18 +1517,29 @@ test("opens the gallery after an intent prefetch fails", async ({ page }) => {
   expect(errors).toEqual([])
 })
 
-test("shows about and the complete work history together", async ({ page }) => {
+test("shows about and the work history summary together", async ({ page }) => {
   await page.goto("/")
   const panel = page.locator("#about-panel")
 
-  await expect(panel.getByText(/Hi, I.m Rafael/)).toBeVisible()
+  await expect(panel.locator(".mosaic-about-lede")).toBeVisible()
   await expect(panel.getByRole("heading", { name: "Work history" })).toBeVisible()
 
   const entries = panel.locator(".mosaic-about-resume-entry")
-  await expect(entries.first()).toContainText("Stealth")
-  await expect(entries.first()).toContainText("Founder · Mar 2026 - Present")
-  await expect(entries.first()).toContainText("Building a mobile wallet product.")
+  await expect(entries.first()).toContainText("Startup")
+  await expect(entries.first().locator(".mosaic-about-resume-title")).toHaveText("Co-founder at Startup")
+  await expect(entries.first().locator(".mosaic-about-resume-dates")).toHaveText("2026 - Present")
+  await expect(entries.first()).toContainText(
+    "Building a mobile wallet for colmados, helping neighborhood store owners in the Dominican Republic manage payments and day-to-day finances from their phones.",
+  )
   await expect(entries.nth(1)).toContainText("0x Project")
+  await expect(entries.nth(1).locator(".mosaic-about-resume-dates")).toHaveText("2021 - 2026")
+  await expect(entries.nth(1).locator(".mosaic-about-resume-description")).toHaveText(
+    "Redesigned Matcha.xyz from scratch and introduced monetization flows that generated sustainable revenue.",
+  )
+  const tmDescription = entries.nth(4).locator(".mosaic-about-resume-description")
+  await expect(tmDescription).toHaveText(
+    "Chainlink: collaborated on internal product tools and the brand system, helping make a complex blockchain oracle network clearer and more consistent as the company scaled.",
+  )
   await expect(panel).toContainText("Incubeta")
   await expect(panel).toContainText("NOVA Community College")
   await expect(panel).toContainText("ITLA")
@@ -1526,63 +1556,161 @@ test("shows about and the complete work history together", async ({ page }) => {
   )
 
   await expect(panel.getByRole("button", { name: /Palm tree sticker/ })).toBeVisible()
-  await expect(panel.getByRole("button", { name: /Briefcase sticker/ })).toBeVisible()
+  await expect(panel.getByRole("button", { name: /Briefcase sticker/ })).toHaveCount(0)
 })
 
-test("keeps work-history stickers inside the work-history section", async ({ page }) => {
-  await page.setViewportSize({ width: 1440, height: 900 })
+test("uses the visible about lede as the section heading", async ({ page }) => {
+  await page.goto("/#about-panel")
+
+  const intro = page.locator("#about-section .mosaic-about-section-copy")
+  const heading = intro.getByRole("heading", { name: "About me" })
+
+  await expect(heading).toHaveClass(/mosaic-about-lede/)
+  await expect(heading).not.toHaveClass(/sr-only/)
+  await expect(intro.locator(":scope > p")).toHaveCount(3)
+  await expect(intro.locator(".mosaic-about-facts")).toHaveCount(0)
+})
+
+test("adds breathing room above the about hobbies", async ({ page }) => {
+  await page.goto("/#about-panel")
+
+  await expect(page.locator(".mosaic-about-hobbies")).toHaveCSS("margin-top", "8px")
+})
+
+test("presents work history as a focused summary", async ({ page }) => {
   await page.goto("/#about-panel-resume")
 
   const workHistory = page.locator("#about-panel-resume")
-  const sticker = page.getByRole("button", { name: /Briefcase sticker/ })
-
-  await expect(sticker).toBeVisible()
-  expect(await sticker.evaluate((element) => element.parentElement?.id)).toBe("about-panel-resume")
-
-  const bounds = await Promise.all([workHistory.boundingBox(), sticker.boundingBox()])
-  expect(bounds[0]).not.toBeNull()
-  expect(bounds[1]).not.toBeNull()
-  expect(bounds[1]!.x).toBeGreaterThanOrEqual(bounds[0]!.x)
-  expect(bounds[1]!.x + bounds[1]!.width).toBeLessThanOrEqual(bounds[0]!.x + bounds[0]!.width)
+  await expect(workHistory.getByRole("link", { name: "Full résumé" })).toHaveAttribute(
+    "href",
+    "/rafael-medina-resume.pdf",
+  )
+  await expect(workHistory.locator(".mosaic-about-lede")).toHaveCount(0)
+  await expect(
+    workHistory.locator(".mosaic-about-work-list > .mosaic-about-work-entry .mosaic-about-resume-description"),
+  ).toHaveCount(6)
+  await expect(workHistory.locator(".mosaic-about-sticker")).toHaveCount(0)
 })
 
-test("spreads each sticker set across the full desktop section gutters", async ({ page }) => {
+test("omits the work-history summary paragraph", async ({ page }) => {
+  await page.goto("/#about-panel-resume")
+
+  await expect(
+    page.getByText(
+      "Ten years designing web3, fintech, and consumer products — from early strategy to shipped interfaces.",
+      { exact: true },
+    ),
+  ).toHaveCount(0)
+})
+
+test("starts the experience list without a top hairline", async ({ page }) => {
+  await page.goto("/#about-panel-resume")
+
+  await expect(
+    page.locator(".mosaic-about-work-history-copy > .mosaic-about-resume > .mosaic-about-resume-entry").first(),
+  ).toHaveCSS("border-top-width", "0px")
+})
+
+test("starts the education section without a top hairline", async ({ page }) => {
+  await page.goto("/#about-panel-resume")
+
+  await expect(page.locator(".mosaic-about-resume-education")).toHaveCSS("border-top-width", "0px")
+})
+
+test("formats desktop work history as dates beside role, company, location, and description", async ({ page }) => {
+  await page.setViewportSize({ width: 650, height: 900 })
+  await page.goto("/#about-panel-resume")
+
+  const entry = page.locator(".mosaic-about-resume-entry").first()
+  const dates = entry.locator(".mosaic-about-resume-dates")
+  const details = entry.locator(".mosaic-about-resume-details")
+
+  await expect(entry.getByRole("heading", { name: "Co-founder at Startup" })).toBeVisible()
+  await expect(entry.locator(".mosaic-about-resume-location")).toHaveText("Remote")
+  await expect(entry.locator(".mosaic-about-resume-description")).toHaveText(
+    "Building a mobile wallet for colmados, helping neighborhood store owners in the Dominican Republic manage payments and day-to-day finances from their phones.",
+  )
+  await expect(entry.locator(".mosaic-about-resume-description")).toHaveCSS("margin-top", "12px")
+
+  const [datesBox, detailsBox] = await Promise.all([dates.boundingBox(), details.boundingBox()])
+  expect(datesBox).not.toBeNull()
+  expect(detailsBox).not.toBeNull()
+  expect(datesBox!.x).toBeLessThan(detailsBox!.x)
+  expect(datesBox!.y).toBeCloseTo(detailsBox!.y, 0)
+})
+
+test("gives the Chainlink work a fuller description", async ({ page }) => {
+  await page.goto("/#about-panel-resume")
+
+  const chainlinkEntry = page
+    .locator(".mosaic-about-work-entry")
+    .filter({ has: page.getByRole("heading", { name: "Product Designer & Frontend Developer at TM (Chainlink, Twilio, and Onit)" }) })
+
+  await expect(chainlinkEntry.locator(".mosaic-about-resume-description")).toContainText(
+    "Chainlink: collaborated on internal product tools and the brand system, helping make a complex blockchain oracle network clearer and more consistent as the company scaled.",
+  )
+})
+
+test("formats education with dates beside its details and extra section spacing", async ({ page }) => {
+  await page.setViewportSize({ width: 650, height: 900 })
+  await page.goto("/#about-panel-resume")
+
+  const education = page.locator(".mosaic-about-resume-education")
+  const entry = education.locator(".mosaic-about-resume-entry").first()
+  const dates = entry.locator(".mosaic-about-resume-dates")
+  const details = entry.locator(".mosaic-about-resume-details")
+
+  await expect(entry.getByRole("heading", { name: "Computer Science at CCI Program - NOVA Community College" })).toBeVisible()
+  await expect(dates).toHaveText("2016 - 2018")
+  await expect(entry.locator(".mosaic-about-resume-location")).toHaveText("Washington, DC")
+
+  const [sectionBox, lastJobBox, datesBox, detailsBox] = await Promise.all([
+    education.boundingBox(),
+    page.locator(".mosaic-about-work-list > .mosaic-about-work-entry").last().boundingBox(),
+    dates.boundingBox(),
+    details.boundingBox(),
+  ])
+  expect(sectionBox).not.toBeNull()
+  expect(lastJobBox).not.toBeNull()
+  expect(datesBox).not.toBeNull()
+  expect(detailsBox).not.toBeNull()
+  expect(sectionBox!.y - (lastJobBox!.y + lastJobBox!.height)).toBeGreaterThanOrEqual(64)
+  expect(datesBox!.x).toBeLessThan(detailsBox!.x)
+  expect(datesBox!.y).toBeCloseTo(detailsBox!.y, 0)
+})
+
+test("spreads the about stickers across the full desktop section gutters", async ({ page }) => {
   await page.setViewportSize({ width: 2560, height: 1239 })
   await page.goto("/#about-panel")
 
-  const layouts = await page.locator("#about-section, #about-panel-resume").evaluateAll((sections) =>
-    sections.map((section) => {
-      const sectionRect = section.getBoundingClientRect()
-      const stickers = Array.from(section.querySelectorAll<HTMLElement>(".mosaic-about-sticker"))
-      const centers = stickers.map((sticker) => {
-        const rect = sticker.getBoundingClientRect()
-        return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 }
-      })
-      const nearestEdgeInsets = centers.map(({ x }) =>
-        Math.min(x - sectionRect.left, sectionRect.right - x),
-      )
-      const verticalCenters = centers.map(({ y }) => y)
+  const layout = await page.locator("#about-section").evaluate((section) => {
+    const sectionRect = section.getBoundingClientRect()
+    const stickers = Array.from(section.querySelectorAll<HTMLElement>(".mosaic-about-sticker"))
+    const centers = stickers.map((sticker) => {
+      const rect = sticker.getBoundingClientRect()
+      return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 }
+    })
+    const nearestEdgeInsets = centers.map(({ x }) =>
+      Math.min(x - sectionRect.left, sectionRect.right - x),
+    )
+    const verticalCenters = centers.map(({ y }) => y)
 
-      return {
-        stickerCount: stickers.length,
-        allInOuterGutters: nearestEdgeInsets.every((inset) => inset <= sectionRect.width * 0.08),
-        verticalCoverage:
-          verticalCenters.length > 0
-            ? (Math.max(...verticalCenters) - Math.min(...verticalCenters)) / sectionRect.height
-            : 0,
-      }
-    }),
-  )
+    return {
+      stickerCount: stickers.length,
+      allInOuterGutters: nearestEdgeInsets.every((inset) => inset <= sectionRect.width * 0.08),
+      verticalCoverage:
+        verticalCenters.length > 0
+          ? (Math.max(...verticalCenters) - Math.min(...verticalCenters)) / sectionRect.height
+          : 0,
+    }
+  })
 
-  expect(layouts).toHaveLength(2)
-  for (const layout of layouts) {
-    expect(layout.stickerCount).toBe(8)
-    expect(layout.allInOuterGutters).toBe(true)
-    expect(layout.verticalCoverage).toBeGreaterThan(0.75)
-  }
+  expect(layout.stickerCount).toBe(8)
+  expect(layout.allInOuterGutters).toBe(true)
+  expect(layout.verticalCoverage).toBeGreaterThan(0.75)
 })
 
-test("gives work history more top breathing room without disconnecting it from about", async ({ page }) => {
+test("keeps 140px between the about close and the work-history heading on desktop", async ({ page }) => {
   await page.setViewportSize({ width: 1440, height: 900 })
   await page.goto("/#about-panel")
 
@@ -1593,8 +1721,7 @@ test("gives work history more top breathing room without disconnecting it from a
     return Math.round(heading.getBoundingClientRect().top - closing.getBoundingClientRect().bottom)
   })
 
-  expect(gap).toBeGreaterThanOrEqual(72)
-  expect(gap).toBeLessThanOrEqual(80)
+  expect(gap).toBe(140)
 })
 
 test("left aligns the work-history reading hierarchy", async ({ page }) => {
@@ -1602,53 +1729,112 @@ test("left aligns the work-history reading hierarchy", async ({ page }) => {
 
   const alignment = await page.locator("#about-panel-resume").evaluate((section) => {
     const heading = section.querySelector("#about-work-history-heading")
-    const company = section.querySelector(".mosaic-about-resume-company")
+    const title = section.querySelector(".mosaic-about-resume-title")
     return {
       section: getComputedStyle(section).textAlign,
       heading: heading ? getComputedStyle(heading).textAlign : null,
-      companyJustification: company ? getComputedStyle(company).justifyContent : null,
+      title: title ? getComputedStyle(title).textAlign : null,
     }
   })
 
-  expect(alignment).toEqual({ section: "left", heading: "left", companyJustification: "flex-start" })
+  expect(alignment).toEqual({ section: "left", heading: "left", title: "left" })
 })
 
 test("reveals company logo tooltips on hover and keyboard focus", async ({ page }) => {
   await page.setViewportSize({ width: 1440, height: 900 })
   await page.goto("/#about-panel-resume")
 
-  const trigger = page.getByRole("button", { name: "Show 0x Project logos" })
-  const tooltip = page.getByRole("tooltip", { name: "0x Project logos" })
+  const companyLink = page.getByRole("link", { name: "0x Project", exact: true })
+  const tooltip = companyLink.locator(".mosaic-company-inline-hover-logos")
 
   await expect(tooltip).toBeHidden()
-  await trigger.hover()
+  await companyLink.hover()
   await expect(tooltip).toBeVisible()
+  await expect(tooltip.locator("img")).toHaveCount(2)
   await page.mouse.move(0, 0)
   await expect(tooltip).toBeHidden()
-  await trigger.focus()
+  await companyLink.focus()
+  await expect(tooltip).toBeVisible()
+})
+
+test("keeps a keyboard-focused company logo tooltip populated after pointer leave", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 })
+  await page.goto("/#about-panel-resume")
+
+  const companyLink = page.getByRole("link", { name: "0x Project", exact: true })
+  const tooltip = companyLink.locator(".mosaic-company-inline-hover-logos")
+
+  await companyLink.focus()
+  await companyLink.hover()
+  await page.mouse.move(0, 0)
+
+  await expect(companyLink).toBeFocused()
   await expect(tooltip).toBeVisible()
   await expect(tooltip.locator("img")).toHaveCount(2)
 })
 
-test("keeps each employer as the accessible work-history heading", async ({ page }) => {
+test("dismisses a keyboard-focused company logo tooltip with Escape", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 })
   await page.goto("/#about-panel-resume")
 
-  await expect(page.getByRole("heading", { name: "0x Project", exact: true })).toBeVisible()
-  await expect(page.getByRole("button", { name: "Show 0x Project logos" })).toBeVisible()
+  const companyLink = page.getByRole("link", { name: "0x Project", exact: true })
+  const tooltip = companyLink.locator(".mosaic-company-inline-hover-logos")
+
+  await companyLink.focus()
+  await expect(tooltip).toBeVisible()
+  await companyLink.press("Escape")
+
+  await expect(companyLink).toBeFocused()
+  await expect(tooltip).toBeHidden()
 })
 
-test("keeps focus on a company trigger when Escape dismisses its logo tooltip", async ({ page }) => {
+test("links each work-history company name to its primary website", async ({ page }) => {
+  await page.goto("/#about-panel-resume")
+  const workHistory = page.locator("#about-panel-resume")
+
+  const projects = [
+    { company: "0x Project", href: "https://0x.org/" },
+    { company: "BoldVoice", href: "https://boldvoice.com/" },
+    { company: "Moody's", href: "https://www.moodys.com/" },
+    { company: "TM (Chainlink, Twilio, and Onit)", href: "https://chain.link/" },
+    { company: "Incubeta (Google)", href: "https://www.google.com/" },
+  ]
+
+  for (const project of projects) {
+    const companyLink = workHistory.getByRole("link", { name: project.company, exact: true })
+    await expect(companyLink).toHaveAttribute("href", project.href)
+    await expect(companyLink).toHaveAttribute("target", "_blank")
+  }
+})
+
+test("opens a work-history company website from its name", async ({ page }) => {
+  await page.context().route("https://0x.org/**", (route) =>
+    route.fulfill({ contentType: "text/html", body: "<!doctype html><title>0x</title>" }),
+  )
   await page.goto("/#about-panel-resume")
 
-  const trigger = page.getByRole("button", { name: "Show 0x Project logos" })
-  const tooltip = page.getByRole("tooltip", { name: "0x Project logos" })
-  await trigger.focus()
-  await expect(tooltip).toBeVisible()
+  const companyLink = page.getByRole("link", { name: "0x Project", exact: true })
 
-  await trigger.press("Escape")
+  const popupPromise = page.waitForEvent("popup")
+  await companyLink.click()
+  const popup = await popupPromise
+  await expect.poll(() => popup.url()).toContain("0x.org")
+  await popup.close()
+})
 
-  await expect(tooltip).toBeHidden()
-  await expect(trigger).toBeFocused()
+test("keeps each role and employer as the accessible work-history heading", async ({ page }) => {
+  await page.goto("/#about-panel-resume")
+
+  await expect(page.getByRole("heading", { name: "Senior Product Designer at 0x Project" })).toBeVisible()
+  await expect(page.getByRole("link", { name: "0x Project", exact: true })).toBeVisible()
+})
+
+test("keeps work-history logo tooltips non-interactive", async ({ page }) => {
+  await page.goto("/#about-panel-resume")
+
+  const companyLink = page.getByRole("link", { name: "0x Project", exact: true })
+  await companyLink.hover()
+  await expect(companyLink.locator(".mosaic-company-inline-hover-logos").getByRole("link")).toHaveCount(0)
 })
 
 test("defers resume-only company logos until their tooltip opens", async ({ page }) => {
@@ -1664,7 +1850,7 @@ test("defers resume-only company logos until their tooltip opens", async ({ page
   expect(requestedLogoPaths).not.toContain(boldVoiceLogoPath)
 
   const request = page.waitForRequest((candidate) => new URL(candidate.url()).pathname === boldVoiceLogoPath)
-  await page.getByRole("button", { name: "Show BoldVoice logos" }).focus()
+  await page.getByRole("link", { name: "BoldVoice", exact: true }).focus()
   await request
 })
 
@@ -1755,7 +1941,7 @@ test("keeps desktop gallery navigation fixed near the modal top", async ({ page 
 
   await next.click()
   await next.click()
-  await expect(dialog.locator(".preview-gallery-count")).toHaveText("3 / 12")
+  await expect(dialog.locator(".preview-gallery-count")).toHaveText("3 / 11")
 
   const changedDialogBox = await dialog.boundingBox()
   const changedRailBox = await rail.boundingBox()
@@ -1766,7 +1952,7 @@ test("keeps desktop gallery navigation fixed near the modal top", async ({ page 
   expect(changedRailBox!.y).toBeCloseTo(initialRailBox!.y, 0)
 
   await previous.click()
-  await expect(dialog.locator(".preview-gallery-count")).toHaveText("2 / 12")
+  await expect(dialog.locator(".preview-gallery-count")).toHaveText("2 / 11")
 })
 
 test("does not use dots to navigate between projects in the main feed", async ({ page }) => {
@@ -1960,7 +2146,10 @@ test("travels one role-bearing work-history popover between company triggers wit
   expect(onitPopoverBox!.y).toBeGreaterThan(onitTriggerBox!.y + onitTriggerBox!.height)
   expect(onitLocationBox!.y).toBeCloseTo(initialLocationBox!.y, 0)
 
-  await page.getByRole("link", { name: "Moody's", exact: true }).hover()
+  await page
+    .locator(".mosaic-work-history")
+    .getByRole("link", { name: "Moody's", exact: true })
+    .hover()
   await expect(popover.locator(".mosaic-work-history-popover-name")).toHaveText("Moody's")
   await expect(popover.locator(".mosaic-work-history-popover-role")).toHaveText("Frontend dev and designer")
   expect(


### PR DESCRIPTION
Refines the About takeover with tighter copy, more runway, a matching shadow, and an 11-project grid capped at three cards per row. Redesigns Work history and Education as responsive date/detail summaries, links company names to their sites with decorative logo previews, and adds the full résumé action. Updates CV data and the design-system inventory, and expands Playwright coverage for layout, interactions, accessibility, and gallery counts. Validation: `npm run lint`, `npm run build`, `npm run test:e2e` (152 passed), and `npm run test:design-system` (5 passed).