### PR TITLE
Add elastic bottom scroll edge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,11 @@
 # AGENTS.md
 
+## Interaction preference
+
+For small, clear changes and direct follow-up corrections, implement and verify
+without asking for another approval round. Ask only when a decision is genuinely
+ambiguous, risky, destructive, or requires new authority.
+
 ## Design system
 
 `/design-system` (dev server only — `npm run dev`, then

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense } from "react"
 
+import { BottomOverscrollEffect } from "./components/BottomOverscrollEffect"
 import { SimpleFeed } from "./components/SimpleFeed"
 import { portfolioCards, siteLinks, siteProfile } from "./data/portfolio"
 
@@ -37,9 +38,12 @@ function App() {
             <DesignSystemPage links={siteLinks} name={siteProfile.name} />
           </Suspense>
         ) : (
-          <main id="main-content" tabIndex={-1} className="relative z-dock">
-            <SimpleFeed cards={portfolioCards} profile={siteProfile} links={siteLinks} />
-          </main>
+          <>
+            <main id="main-content" tabIndex={-1} className="relative z-dock">
+              <SimpleFeed cards={portfolioCards} profile={siteProfile} links={siteLinks} />
+            </main>
+            <BottomOverscrollEffect />
+          </>
         )}
         {Agentation ? (
           <Suspense fallback={null}>

--- a/src/components/BottomOverscrollEffect.tsx
+++ b/src/components/BottomOverscrollEffect.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useRef } from "react"
+
+const MAX_PULL = 72
+const MAX_OPACITY = 0.92
+const RELEASE_DELAY_MS = 90
+
+function isAtDocumentBottom() {
+  const root = document.documentElement
+  return window.scrollY + window.innerHeight >= root.scrollHeight - 1
+}
+
+function isInsideScrollableRegion(target: EventTarget | null) {
+  let element = target instanceof Element ? target : null
+
+  while (element && element !== document.documentElement) {
+    const styles = window.getComputedStyle(element)
+    const canScroll = /(auto|scroll)/.test(styles.overflowY) && element.scrollHeight > element.clientHeight + 1
+    if (canScroll) return true
+    element = element.parentElement
+  }
+
+  return false
+}
+
+export function BottomOverscrollEffect() {
+  const edgeRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    const edge = edgeRef.current
+    if (!edge || typeof window.matchMedia !== "function") return
+
+    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)")
+    let pull = 0
+    let lastTouchY: number | null = null
+    let releaseTimer: number | undefined
+
+    const paint = (nextPull: number) => {
+      pull = Math.max(0, Math.min(MAX_PULL, nextPull))
+      const progress = pull / MAX_PULL
+
+      edge.style.setProperty("--elastic-edge-opacity", String(progress * MAX_OPACITY))
+      edge.style.setProperty("--elastic-edge-offset", `${(1 - progress) * 44}px`)
+      edge.style.setProperty("--elastic-edge-scale", String(0.35 + progress * 0.65))
+    }
+
+    const release = () => {
+      if (releaseTimer !== undefined) window.clearTimeout(releaseTimer)
+      releaseTimer = undefined
+      if (pull === 0) return
+
+      edge.dataset.pulling = "false"
+      // Let the release transition take over from the exact point reached by
+      // the gesture, including when intent reverses mid-pull.
+      void edge.offsetHeight
+      paint(0)
+    }
+
+    const scheduleRelease = () => {
+      if (releaseTimer !== undefined) window.clearTimeout(releaseTimer)
+      releaseTimer = window.setTimeout(release, RELEASE_DELAY_MS)
+    }
+
+    const pullBy = (distance: number) => {
+      if (reducedMotion.matches || distance <= 0) return
+
+      if (edge.dataset.pulling !== "true") {
+        // Release writes the resting target immediately, so recover the value
+        // still being rendered before interrupting its transition.
+        const renderedOpacity = Number.parseFloat(window.getComputedStyle(edge).opacity)
+        if (Number.isFinite(renderedOpacity)) {
+          pull = Math.max(0, Math.min(MAX_PULL, (renderedOpacity / MAX_OPACITY) * MAX_PULL))
+        }
+      }
+
+      edge.dataset.pulling = "true"
+      // Resistance increases near the limit, like a short rubber sheet rather
+      // than a progress bar that stops abruptly.
+      const resistance = 1 - (pull / MAX_PULL) * 0.55
+      paint(pull + distance * 0.24 * resistance)
+      scheduleRelease()
+    }
+
+    const handleWheel = (event: WheelEvent) => {
+      if (
+        event.ctrlKey ||
+        event.deltaY <= 0 ||
+        Math.abs(event.deltaY) < Math.abs(event.deltaX) ||
+        !isAtDocumentBottom() ||
+        isInsideScrollableRegion(event.target)
+      ) {
+        if (event.deltaY < 0) release()
+        return
+      }
+
+      pullBy(event.deltaY)
+    }
+
+    const handleTouchStart = (event: TouchEvent) => {
+      lastTouchY = event.touches[0]?.clientY ?? null
+    }
+
+    const handleTouchMove = (event: TouchEvent) => {
+      const currentY = event.touches[0]?.clientY
+      if (currentY == null || lastTouchY == null) return
+
+      const distance = lastTouchY - currentY
+      lastTouchY = currentY
+
+      if (distance > 0 && isAtDocumentBottom() && !isInsideScrollableRegion(event.target)) {
+        pullBy(distance)
+      } else if (distance < 0) {
+        release()
+      }
+    }
+
+    const handleTouchEnd = () => {
+      lastTouchY = null
+      release()
+    }
+
+    const handleScroll = () => {
+      if (!isAtDocumentBottom()) release()
+    }
+
+    const handleMotionPreference = () => {
+      if (reducedMotion.matches) release()
+    }
+
+    window.addEventListener("wheel", handleWheel, { passive: true })
+    window.addEventListener("scroll", handleScroll, { passive: true })
+    document.addEventListener("touchstart", handleTouchStart, { passive: true })
+    document.addEventListener("touchmove", handleTouchMove, { passive: true })
+    document.addEventListener("touchend", handleTouchEnd, { passive: true })
+    document.addEventListener("touchcancel", handleTouchEnd, { passive: true })
+    reducedMotion.addEventListener("change", handleMotionPreference)
+
+    return () => {
+      if (releaseTimer !== undefined) window.clearTimeout(releaseTimer)
+      window.removeEventListener("wheel", handleWheel)
+      window.removeEventListener("scroll", handleScroll)
+      document.removeEventListener("touchstart", handleTouchStart)
+      document.removeEventListener("touchmove", handleTouchMove)
+      document.removeEventListener("touchend", handleTouchEnd)
+      document.removeEventListener("touchcancel", handleTouchEnd)
+      reducedMotion.removeEventListener("change", handleMotionPreference)
+    }
+  }, [])
+
+  return (
+    <div ref={edgeRef} className="elastic-scroll-edge" data-pulling="false" aria-hidden="true">
+      <div className="elastic-scroll-edge-shade" />
+    </div>
+  )
+}

--- a/src/components/DesignSystemPage.tsx
+++ b/src/components/DesignSystemPage.tsx
@@ -276,7 +276,7 @@ const ELEVATION = [
   {
     name: "Hover card",
     shadow: "0 1px 2px rgb(16 16 20 / 0.06), 0 12px 32px rgb(16 16 20 / 0.16)",
-    use: "LinkedIn and X cards, the work-history popover, and the About takeover. A tight contact shadow plus one wide ambient.",
+    use: "LinkedIn and X cards, the work-history popover, and the top edge of the About takeover. A tight contact shadow plus one wide ambient.",
   },
   {
     name: "Dialog",
@@ -327,8 +327,8 @@ const EASINGS = [
   {
     name: "First load",
     css: "cubic-bezier(0.19, 1, 0.22, 1)",
-    duration: "380–480ms",
-    use: "--ease-smooth. The hero and mosaic intro cascades; the avatar press reuses it at 160ms.",
+    duration: "160–700ms",
+    use: "--ease-smooth. The hero and mosaic intro cascades; the bottom scroll edge uses a slower 700ms physical settle; the avatar press reuses it at 160ms.",
   },
   {
     name: "Coin flip",
@@ -357,7 +357,7 @@ const DURATIONS = [
   { value: "300ms", use: "The gallery expand/minimise icon swap." },
   { value: "360ms", use: "Media un-blurring as it decodes." },
   { value: "380–480ms", use: "First-load entrance travel, hero then mosaic." },
-  { value: "700ms", use: "The avatar coin flip — a deliberate outlier, and the longest thing on the site." },
+  { value: "700ms", use: "The bottom scroll edge's synchronized physical settle and the avatar coin flip." },
 ]
 
 /* ------------------------------------------------------------------ layout */
@@ -377,7 +377,7 @@ const BREAKPOINTS = [
 ]
 
 const STACKING = [
-  { z: "0–20", name: "Base, dock, chrome", note: "Tailwind's z-base / z-dock / z-chrome. The page and the mosaic." },
+  { z: "0–20", name: "Base, dock, chrome", note: "Tailwind's z-base / z-dock / z-chrome. The page, mosaic, and bottom scroll edge." },
   { z: "1", name: "About sheet", note: "The full-viewport white surface paints above the pinned project gallery during takeover." },
   {
     z: "30 / 50",
@@ -528,6 +528,18 @@ export function DesignSystemPage({ links, name }: DesignSystemPageProps) {
                     </div>
                   </article>
                 ))}
+              </div>
+            </div>
+
+            <div className="ds-block">
+              <p className="ds-subhead">Elastic page edge</p>
+              <div className="ds-rule">
+                <strong>One neutral rubber sheet.</strong>
+                <p>
+                  The 56px page-end curve reuses <code>--mosaic-card-surface</code> and fades it to transparent. It has
+                  one layer, no blur, no distortion, and no separate hue; the gesture and release motion provide the
+                  effect instead of decorative rendering.
+                </p>
               </div>
             </div>
 
@@ -1121,7 +1133,8 @@ export function DesignSystemPage({ links, name }: DesignSystemPageProps) {
                   remain in one sticky stage at their original sizes and 1rem gaps, followed by a responsive white
                   runway of <code>clamp(12rem, 30vh, 18rem)</code>.
                   The runway is the gallery's natural height plus <code>100dvh</code>; the gallery pins when its bottom reaches the viewport, then the
-                  full-bleed white About sheet crosses it at z-index 1 with the same layered shadow as the hover cards. The gallery retreats as one surface, and About
+                  full-bleed white About sheet crosses it at z-index 1 with the same layered shadow as the hover cards.
+                  A top-only layer casts that shadow while the white sheet remains continuous through the page end. The gallery retreats as one surface, and About
                   continues in normal flow after the cover. Below 700px both wrappers collapse with{" "}
                   <code>display: contents</code>; the white sheet stays full-bleed but no pinning or overlap is applied.
                 </li>

--- a/src/index.css
+++ b/src/index.css
@@ -44,6 +44,7 @@
   /* Focus indicators need 3:1 against the adjacent surface (WCAG 1.4.11), which
      rules out the greys in --accent's range on our near-white backgrounds. */
   --focus-ring: #2d2d2d;
+  --elastic-edge-height: 56px;
   --overlay-filter: blur(1rem);
   --overlay-background: hsla(0, 0%, 100%, 0.8);
   --overlay-shadow:
@@ -168,6 +169,42 @@ img {
 
 #root {
   min-height: 100dvh;
+}
+
+.elastic-scroll-edge {
+  --elastic-edge-opacity: 0;
+  --elastic-edge-offset: 44px;
+  --elastic-edge-scale: 0.35;
+
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 20;
+  height: calc(var(--elastic-edge-height) + env(safe-area-inset-bottom));
+  pointer-events: none;
+  opacity: var(--elastic-edge-opacity);
+  transform: translate3d(0, var(--elastic-edge-offset), 0) scaleY(var(--elastic-edge-scale));
+  transform-origin: center bottom;
+  transition-property: transform, opacity;
+  transition-duration: 700ms;
+  transition-timing-function: var(--ease-smooth);
+  will-change: transform, opacity;
+}
+
+.elastic-scroll-edge-shade {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    ellipse 90% 120% at 50% 120%,
+    var(--mosaic-card-surface) 0%,
+    rgb(236 236 238 / 0.66) 48%,
+    transparent 100%
+  );
+}
+
+.elastic-scroll-edge[data-pulling="true"] {
+  transition-duration: 0ms;
 }
 
 .mosaic-shell {
@@ -2350,11 +2387,28 @@ img {
   .mosaic-about {
     margin-top: -100vh;
     margin-top: -100dvh;
+    view-timeline-name: --about-takeover;
+    view-timeline-axis: block;
+  }
+
+  .mosaic-about::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    left: 0;
+    z-index: 0;
+    height: 1px;
+    pointer-events: none;
     box-shadow:
       0 1px 2px rgb(16 16 20 / 0.06),
       0 12px 32px rgb(16 16 20 / 0.16);
-    view-timeline-name: --about-takeover;
-    view-timeline-axis: block;
+  }
+
+  /* The solid panel covers the shadow below its top edge. The shadow can
+     still lift over the gallery, while the sheet has no painted bottom edge. */
+  .mosaic-about-panel {
+    z-index: 1;
   }
 }
 
@@ -3398,5 +3452,9 @@ img {
 
   .mosaic-live-time {
     overflow: visible;
+  }
+
+  .elastic-scroll-edge {
+    display: none;
   }
 }

--- a/tests/design-system/design-system.spec.ts
+++ b/tests/design-system/design-system.spec.ts
@@ -100,3 +100,11 @@ test("documents component-specific motion curves that still ship", async ({ page
     expect(documentedCurves).toContain(curve)
   }
 })
+
+test("keeps the restored neutral elastic edge free of its former tuning panel", async ({ page }) => {
+  await page.goto("/")
+  await page.waitForLoadState("networkidle")
+
+  const dial = page.locator(".dialkit-panel-wrapper").filter({ hasText: "Elastic scroll edge" })
+  await expect(dial).toHaveCount(0)
+})

--- a/tests/e2e/portfolio-polish.spec.ts
+++ b/tests/e2e/portfolio-polish.spec.ts
@@ -44,6 +44,121 @@ test("hydrates the prerendered portfolio without browser errors", async ({ page,
   expect(errors).toEqual([])
 })
 
+test("compresses a soft light-gray edge into view when scrolling past the page bottom", async ({ page }) => {
+  await page.goto("/")
+  await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight))
+
+  const edge = page.locator(".elastic-scroll-edge")
+  const pulledState = await edge.evaluate((element) => {
+    window.dispatchEvent(new WheelEvent("wheel", { deltaY: 600 }))
+    const styles = getComputedStyle(element)
+    const shade = element.querySelector<HTMLElement>(".elastic-scroll-edge-shade")
+    return {
+      pulling: element.getAttribute("data-pulling"),
+      inlineOpacity: (element as HTMLElement).style.getPropertyValue("--elastic-edge-opacity"),
+      pointerEvents: styles.pointerEvents,
+      height: Number.parseFloat(styles.height),
+      shadeCount: element.querySelectorAll(".elastic-scroll-edge-shade").length,
+      shadeFilter: shade ? getComputedStyle(shade).filter : "missing",
+      backgroundImage: shade ? getComputedStyle(shade).backgroundImage : "none",
+    }
+  })
+
+  expect(pulledState.pulling).toBe("true")
+  expect(Number(pulledState.inlineOpacity)).toBeGreaterThanOrEqual(0.9)
+  expect(pulledState.pointerEvents).toBe("none")
+  expect(pulledState.height).toBeGreaterThanOrEqual(40)
+  expect(pulledState.height).toBeLessThanOrEqual(72)
+  expect(pulledState.shadeCount).toBe(1)
+  expect(pulledState.shadeFilter).toBe("none")
+  const saturatedStops = [...pulledState.backgroundImage.matchAll(/rgba?\((\d+),\s*(\d+),\s*(\d+)/g)]
+    .map(([, red, green, blue]) => [Number(red), Number(green), Number(blue)])
+    .filter((channels) => Math.max(...channels) - Math.min(...channels) >= 12)
+  expect(saturatedStops).toHaveLength(0)
+  expect(pulledState.backgroundImage).toContain("236, 236, 238")
+  await expect(edge).toHaveAttribute("data-pulling", "false")
+  await expect(edge).toHaveCSS("opacity", "0")
+})
+
+test("releases the elastic scroll edge with one slow physical settle", async ({ page }) => {
+  await page.goto("/")
+  await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight))
+
+  const edge = page.locator(".elastic-scroll-edge")
+  const pullingState = await edge.evaluate((element) => {
+    window.dispatchEvent(new WheelEvent("wheel", { deltaY: 600 }))
+    return {
+      pulling: element.getAttribute("data-pulling"),
+      transitionDuration: getComputedStyle(element).transitionDuration,
+    }
+  })
+
+  expect(pullingState).toEqual({ pulling: "true", transitionDuration: "0s" })
+
+  await expect(edge).toHaveAttribute("data-pulling", "false")
+  await expect(edge).toHaveCSS("transition-duration", "0.7s")
+  await expect(edge).toHaveCSS("transition-timing-function", "cubic-bezier(0.19, 1, 0.22, 1)")
+})
+
+test("continues the elastic scroll edge from its visible position when release is interrupted", async ({ page }) => {
+  await page.goto("/")
+  await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight))
+
+  const edge = page.locator(".elastic-scroll-edge")
+  const interruption = await edge.evaluate(async (element) => {
+    window.dispatchEvent(new WheelEvent("wheel", { deltaY: 600 }))
+    await new Promise((resolve) => window.setTimeout(resolve, 210))
+
+    const opacityBeforeInterruption = Number.parseFloat(getComputedStyle(element).opacity)
+    window.dispatchEvent(new WheelEvent("wheel", { deltaY: 20 }))
+    const opacityAfterInterruption = Number.parseFloat(getComputedStyle(element).opacity)
+
+    return { opacityBeforeInterruption, opacityAfterInterruption }
+  })
+
+  expect(interruption.opacityBeforeInterruption).toBeGreaterThan(0.1)
+  expect(interruption.opacityAfterInterruption).toBeGreaterThanOrEqual(interruption.opacityBeforeInterruption)
+})
+
+test("removes the elastic scroll edge when reduced motion is preferred", async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: "reduce" })
+  await page.goto("/")
+  await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight))
+
+  const edge = page.locator(".elastic-scroll-edge")
+  await edge.evaluate(() => window.dispatchEvent(new WheelEvent("wheel", { deltaY: 180 })))
+
+  await expect(edge).toHaveCSS("display", "none")
+  await expect(edge).toHaveAttribute("data-pulling", "false")
+})
+
+test("keeps the About surface continuous while limiting its shadow to the top edge", async ({ page }) => {
+  await page.goto("/")
+
+  const about = page.locator(".mosaic-about")
+  const treatment = await about.evaluate((element) => {
+    const sheet = getComputedStyle(element)
+    const topEdge = getComputedStyle(element, "::before")
+    const panel = element.querySelector<HTMLElement>(".mosaic-about-panel")
+
+    return {
+      sheetShadow: sheet.boxShadow,
+      sheetClip: sheet.clipPath,
+      topEdgeContent: topEdge.content,
+      topEdgeHeight: topEdge.height,
+      topEdgeShadow: topEdge.boxShadow,
+      panelLayer: panel ? getComputedStyle(panel).zIndex : "missing",
+    }
+  })
+
+  expect(treatment.sheetShadow).toBe("none")
+  expect(treatment.sheetClip).toBe("none")
+  expect(treatment.topEdgeContent).toBe('""')
+  expect(treatment.topEdgeHeight).toBe("1px")
+  expect(treatment.topEdgeShadow).not.toBe("none")
+  expect(treatment.panelLayer).toBe("1")
+})
+
 test("does not claim a sitemap modification date for every deployment", async ({ request }) => {
   const response = await request.get("/sitemap.xml")
 
@@ -1084,7 +1199,7 @@ test("reuses the hover-card shadow for the about takeover", async ({ page }) => 
   const hoverCard = page.locator(".mosaic-linkedin-card")
 
   const [aboutShadow, hoverCardShadow] = await Promise.all([
-    about.evaluate((element) => getComputedStyle(element).boxShadow),
+    about.evaluate((element) => getComputedStyle(element, "::before").boxShadow),
     hoverCard.evaluate((element) => getComputedStyle(element).boxShadow),
   ])
 


### PR DESCRIPTION
## Summary
- Add a neutral elastic bottom-edge response for wheel and touch overscroll, including reduced-motion support and interruption-safe release motion.
- Document the edge in the dev design system, refine the About takeover shadow to its top boundary, and record the small-change interaction preference.
- Expand E2E and design-system coverage for rendering, motion, stacking, and accessibility behavior.

## Testing
- `npm run lint`
- `npm run build`
- `npm run test:e2e` (157 passed)
- `npm run test:design-system` (6 passed)