### PR TITLE
Polish resume links and portfolio interactions

### DIFF
--- a/src/components/AboutPanel.tsx
+++ b/src/components/AboutPanel.tsx
@@ -1,4 +1,5 @@
 import {
+  Fragment,
   useCallback,
   useEffect,
   useRef,
@@ -9,6 +10,7 @@ import {
 } from "react"
 
 import { cvEducation, cvExperience } from "../data/cv"
+import type { CvExperience } from "../data/cv"
 import type { SiteLinks } from "../data/portfolio"
 import { trackEvent } from "../lib/analytics"
 
@@ -279,6 +281,43 @@ function ResumeCompanyLink({ company, href, logoUrls }: { company: string; href:
   )
 }
 
+function getCompanyLabel(job: CvExperience) {
+  if (!job.clients) return job.company
+
+  const clientNames = job.clients.map((client) => client.name)
+  const clients =
+    clientNames.length > 1
+      ? `${clientNames.slice(0, -1).join(", ")}, and ${clientNames.at(-1)}`
+      : clientNames[0]
+
+  return `${job.company} (${clients})`
+}
+
+function ResumeCompany({ job }: { job: CvExperience }) {
+  const clients = job.clients
+
+  if (clients) {
+    return (
+      <>
+        <span>{job.company} (</span>
+        {clients.map((client, index) => (
+          <Fragment key={client.name}>
+            {index > 0 ? (index === clients.length - 1 ? ", and " : ", ") : null}
+            <ResumeCompanyLink company={client.name} href={client.href} logoUrls={[client.logoUrl]} />
+          </Fragment>
+        ))}
+        <span>)</span>
+      </>
+    )
+  }
+
+  if (job.href && job.logoUrls) {
+    return <ResumeCompanyLink company={job.company} href={job.href} logoUrls={job.logoUrls} />
+  }
+
+  return <span>{job.company}</span>
+}
+
 export function AboutPanel({ links }: AboutPanelProps) {
   const { offsets, order, dragging, onKeyDown, onPointerDown, onPointerMove, onPointerUp } =
     useStickerMovement()
@@ -422,14 +461,9 @@ export function AboutPanel({ links }: AboutPanelProps) {
                     <div className="mosaic-about-resume-details">
                       <h3
                         className="mosaic-about-resume-title"
-                        aria-label={`${job.role} at ${job.company}`}
+                        aria-label={`${job.role} at ${getCompanyLabel(job)}`}
                       >
-                        {job.role} at{" "}
-                        {job.href && job.logoUrls ? (
-                          <ResumeCompanyLink company={job.company} href={job.href} logoUrls={job.logoUrls} />
-                        ) : (
-                          <span>{job.company}</span>
-                        )}
+                        {job.role} at <ResumeCompany job={job} />
                       </h3>
                       <p className="mosaic-about-resume-location">{job.location}</p>
                       <p className="mosaic-about-resume-description">{job.highlight}</p>

--- a/src/components/DesignSystemPage.tsx
+++ b/src/components/DesignSystemPage.tsx
@@ -144,10 +144,10 @@ const INK = [
   { hex: "#171717", token: "—", use: "Text inside white cards and the preview dialog" },
   { hex: "#2d2d2d", token: "--focus-ring", use: "Primary UI labels, hover states, and every focus ring" },
   { hex: "#4a4a4a", token: "—", use: "Inline links at rest" },
-  { hex: "#545454", token: "—", use: "About-panel prose" },
+  { hex: "#545454", token: "—", use: "About-panel prose and the Work history heading" },
   { hex: "#6b6b6b", token: "--muted", use: "Secondary copy: subtitles, captions, dialog descriptions" },
   { hex: "#747474", token: "—", use: "Corner nav links and the local-time label" },
-  { hex: "#757575", token: "--muted-soft", use: "Tertiary labels: definition terms, hobby notes, headings" },
+  { hex: "#757575", token: "--muted-soft", use: "Tertiary labels: definition terms and hobby notes" },
 ]
 
 const NON_TEXT = [
@@ -310,7 +310,7 @@ const EASINGS = [
     name: "Gallery open",
     css: "cubic-bezier(0.32, 0.8, 0.32, 1)",
     duration: "200ms",
-    use: "The preview gallery's origin-aware expansion and its fallback lift.",
+    use: "The preview gallery's origin-aware, whole-surface expansion and its fallback lift.",
   },
   {
     name: "Exit",
@@ -363,7 +363,7 @@ const DURATIONS = [
 /* ------------------------------------------------------------------ layout */
 
 const BREAKPOINTS = [
-  { at: "≤ 327.98px", change: "Contact pills use 0.625rem side padding; location and availability stack without a separator." },
+  { at: "≤ 327.98px", change: "Contact pills use 0.625rem side padding; the wrapped X card centers on its trigger; location and availability stack without a separator." },
   { at: "≤ 479.98px", change: "Contact pills gain up to 1.25rem side padding and wrap when their container cannot accommodate them." },
   { at: "≤ 639.98px", change: "The hero reserves 4rem of top clearance." },
   { at: "≤ 699.98px", change: "Local time hides; the 14px About and Resume labels centre optically; the shell uses 8px gutters; every project shows in one 340–380px column; featured media crops to fill its card; the full-bleed About sheet returns to normal document flow; card captions hide." },
@@ -886,7 +886,7 @@ export function DesignSystemPage({ links, name }: DesignSystemPageProps) {
                     <tr>
                       <td>Default</td>
                       <td>
-                        <code>#f4f4f4 → #fff</code> gradient, <code>#dedee0</code> border, 104px min
+                        <code>#f4f4f4 → #fff</code> gradient, <code>#dedee0</code> border, 112px fixed
                       </td>
                       <td>The primary action. One per row.</td>
                     </tr>

--- a/src/components/PreviewGalleryDialog.tsx
+++ b/src/components/PreviewGalleryDialog.tsx
@@ -130,18 +130,14 @@ const easeClose = cubicBezierEasing(closeEasePoints)
 // 120Hz over the longest of these animations.
 const originSampleCount = 48
 
-// The wrapper scales the surface by `s` and the inner layer has to undo it with
-// `1/s`. Easing those two independently does NOT cancel — lerp(s, 1) times
-// lerp(1/s, 1) peaks around 20% off at the midpoint, which shows up as the copy
-// visibly breathing. So the easing is baked into sampled keyframes here and both
-// animations run `linear`, which keeps them exact reciprocals at every offset.
+// Bake the easing into sampled keyframes so the origin-aware translation and
+// scale remain one coordinated motion on the complete gallery surface.
 function buildOriginKeyframes(
   mode: "open" | "close",
   offset: { dx: number; dy: number; scale: number },
 ) {
   const ease = mode === "open" ? easeOpen : easeClose
-  const wrap: Keyframe[] = []
-  const inner: Keyframe[] = []
+  const keyframes: Keyframe[] = []
 
   for (let step = 0; step < originSampleCount; step += 1) {
     const time = step / (originSampleCount - 1)
@@ -152,19 +148,14 @@ function buildOriginKeyframes(
     const dx = offset.dx * (1 - travel)
     const dy = offset.dy * (1 - travel)
 
-    wrap.push({
+    keyframes.push({
       offset: time,
       easing: "linear",
       transform: `translate3d(${dx.toFixed(2)}px, ${dy.toFixed(2)}px, 0) scale(${scale.toFixed(5)})`,
     })
-    inner.push({
-      offset: time,
-      easing: "linear",
-      transform: `scale(${(1 / scale).toFixed(5)})`,
-    })
   }
 
-  return { wrap, inner }
+  return keyframes
 }
 
 function isVideoPreviewSource(source: string) {
@@ -213,7 +204,6 @@ export function PreviewGalleryDialog({
   const switchFrameRef = useRef<number | null>(null)
   const closeResetTimeoutRef = useRef<number | null>(null)
   const originWrapRef = useRef<HTMLDivElement | null>(null)
-  const cardInnerRef = useRef<HTMLDivElement | null>(null)
   const popupRef = useRef<HTMLDivElement | null>(null)
   const originAnimationsRef = useRef<Animation[]>([])
   // The portal mounts its contents in a later commit than the one that flips
@@ -292,10 +282,9 @@ export function PreviewGalleryDialog({
     originInputsRef.current = { getOriginRect, prefersReducedMotion, safeIndex }
   }, [getOriginRect, prefersReducedMotion, safeIndex])
 
-  // A translated (and counter-scaled) child overflows its scroll containers,
-  // which would flash a scrollbar mid-flight, and the rail would ride the scale
-  // down to a speck. One flag on the shell gates both, plus the compositing
-  // hints, and it must come off however the animation ends.
+  // The translated surface can overflow its scroll containers and flash a
+  // scrollbar mid-flight. One flag on the shell gates that clipping and the
+  // compositing hint, and it must come off however the animation ends.
   const clearOriginAnimatingFlag = useCallback(() => {
     originWrapRef.current?.parentElement?.removeAttribute("data-origin-animating")
   }, [])
@@ -329,19 +318,8 @@ export function PreviewGalleryDialog({
       fill: mode === "open" ? "none" : "forwards",
     }
 
-    const travel = wrap.animate(keyframes.wrap, options)
+    const travel = wrap.animate(keyframes, options)
     originAnimationsRef.current = [travel]
-
-    // The surface scales, the content must not: this layer takes the exact
-    // reciprocal, so the copy and the media sit at final size the whole way and
-    // the growing box simply reveals them. Same start time, so the two
-    // transforms cancel on every frame.
-    const inner = cardInnerRef.current
-    if (inner && typeof inner.animate === "function") {
-      const counter = inner.animate(keyframes.inner, options)
-      if (travel.startTime !== null) counter.startTime = travel.startTime
-      originAnimationsRef.current.push(counter)
-    }
 
     wrap.parentElement?.setAttribute("data-origin-animating", "true")
     // Only the open path unlocks on finish. On close the transform is held by
@@ -534,7 +512,7 @@ export function PreviewGalleryDialog({
                   touchStartRef.current = null
                 }}
               >
-                <div className="preview-gallery-card-inner" ref={cardInnerRef}>
+                <div className="preview-gallery-card-inner">
                   <div className="preview-gallery-media-frame" style={mediaFrameStyle}>
                     {activeMediaIsVideo ? (
                       <video

--- a/src/data/cv.ts
+++ b/src/data/cv.ts
@@ -1,5 +1,6 @@
 export type CvExperience = {
   company: string
+  clients?: CvExperienceClient[]
   location: string
   dates: string
   role: string
@@ -7,6 +8,12 @@ export type CvExperience = {
   /** Primary company link and decorative logo tooltip. */
   href?: string
   logoUrls?: string[]
+}
+
+export type CvExperienceClient = {
+  name: string
+  href: string
+  logoUrl: string
 }
 
 export type CvEducation = {
@@ -55,12 +62,15 @@ export const cvExperience: CvExperience[] = [
     highlight: "Redesigned financial-analysis tools for institutional analysts, improving data discovery and workflow efficiency.",
   },
   {
-    company: "TM (Chainlink, Twilio, and Onit)",
+    company: "TM",
+    clients: [
+      { name: "Chainlink", href: "https://chain.link/", logoUrl: "/logos/chainlink.svg" },
+      { name: "Twilio", href: "https://www.twilio.com/", logoUrl: "/logos/twilio.svg" },
+      { name: "Onit", href: "https://www.onit.com/", logoUrl: "/logos/onit.png" },
+    ],
     location: "Remote, Los Angeles",
     dates: "2018 - 2020",
     role: "Product Designer & Frontend Developer",
-    href: "https://chain.link/",
-    logoUrls: ["/logos/chainlink.svg", "/logos/twilio.svg", "/logos/onit.png"],
     highlight:
       "Chainlink: collaborated on internal product tools and the brand system, helping make a complex blockchain oracle network clearer and more consistent as the company scaled.",
   },

--- a/src/index.css
+++ b/src/index.css
@@ -905,7 +905,7 @@ img {
 
 .mosaic-about-section-heading {
   margin: 0;
-  color: var(--muted-soft);
+  color: #545454;
   font-size: var(--text-md);
   font-weight: 400;
   line-height: 1.6;
@@ -1775,7 +1775,7 @@ img {
 }
 
 .mosaic-contact-pill-default {
-  min-width: 104px;
+  width: 7rem;
   border-color: #dedee0;
   background: linear-gradient(180deg, #f4f4f4 0%, #ffffff 69.12%);
   box-shadow: 0 1px 5px rgb(46 42 42 / 0.08);
@@ -2602,6 +2602,13 @@ img {
     padding-inline: 0.625rem;
   }
 
+  .mosaic-x-card {
+    right: auto;
+    left: 50%;
+    translate: -50% 0;
+    transform-origin: top center;
+  }
+
   .mosaic-profile-location {
     flex-direction: column;
     gap: 0.15rem;
@@ -2780,22 +2787,13 @@ img {
   height: 0;
 }
 
-/* The wrapper scales the surface down to the size of the card that was clicked;
-   this layer takes the exact reciprocal, so the media and the copy sit at final
-   size for the whole flight and the growing box just reveals them. Driven by
-   the Web Animations API in the dialog, in lockstep with the wrapper. */
-.preview-gallery-card-inner {
-  transform-origin: top center;
-}
-
-/* Mid-flight the counter-scaled content overflows its box, so the shell flags
-   the travel and the surface clips rather than flashing a scrollbar. */
+/* Mid-flight the translated surface can overflow the shell, so clip it rather
+   than flashing a scrollbar. */
 .preview-gallery-shell[data-origin-animating] .preview-gallery-card {
   overflow: hidden;
 }
 
-.preview-gallery-shell[data-origin-animating] .preview-gallery-origin-wrap,
-.preview-gallery-shell[data-origin-animating] .preview-gallery-card-inner {
+.preview-gallery-shell[data-origin-animating] .preview-gallery-origin-wrap {
   will-change: transform;
 }
 

--- a/tests/e2e/portfolio-polish.spec.ts
+++ b/tests/e2e/portfolio-polish.spec.ts
@@ -14,6 +14,11 @@ const stubCompanySite = (context: BrowserContext) =>
     route.fulfill({ contentType: "text/html", body: "<!doctype html><title>Onit</title>" }),
   )
 
+const getPreviousCompanyLink = (page: Page, name: string) =>
+  page
+    .getByRole("group", { name: "Previous companies" })
+    .getByRole("link", { name, exact: true })
+
 // The work cards cascade in on first load, so a card clicked straight after
 // `goto` can still be sitting at its pre-start offset -- and the gallery grows
 // out of that card's live rect. Settle the cascade before touching a card.
@@ -60,6 +65,26 @@ test("offers LinkedIn and X actions beside copy email", async ({ page }) => {
 
   await expect(linkedInAction).toHaveAttribute("href", "https://www.linkedin.com/in/rafaelmedian")
   await expect(xAction).toHaveAttribute("href", "https://x.com/rafaelmedian")
+})
+
+test("keeps the wider copy-email action fixed when its label changes", async ({ context, page }) => {
+  await context.grantPermissions(["clipboard-write"])
+  await page.setViewportSize({ width: 1728, height: 913 })
+  await page.goto("/")
+  await pausePageClock(page)
+
+  const copyButton = page.locator(".mosaic-profile-contact").getByRole("button")
+  const beforeCopy = await copyButton.boundingBox()
+
+  expect(beforeCopy).not.toBeNull()
+  expect(beforeCopy!.width).toBe(112)
+
+  await copyButton.click()
+  await expect(copyButton).toHaveText("Copied!")
+
+  const afterCopy = await copyButton.boundingBox()
+  expect(afterCopy).not.toBeNull()
+  expect(afterCopy!.width).toBe(beforeCopy!.width)
 })
 
 test("uses the same side padding for every contact action", async ({ page }) => {
@@ -189,6 +214,7 @@ test("uses only the body and lead type steps throughout About", async ({ page })
 
   expect(sizes).toEqual(["16px", "18px"])
   await expect(page.locator(".mosaic-about-section-heading")).toHaveCSS("font-size", "16px")
+  await expect(page.locator(".mosaic-about-section-heading")).toHaveCSS("color", "rgb(84, 84, 84)")
   await expect(page.locator("#about-section .mosaic-about-lede")).toHaveCSS("font-size", "18px")
 
   const workHistorySizes = await page
@@ -1345,6 +1371,31 @@ test("exposes the profile name as a heading rather than burying it in a control"
   await expect(page.locator(".mosaic-profile-meta")).not.toHaveAttribute("tabindex", "0")
 })
 
+test("opens the preview gallery as one coordinated surface", async ({ page }) => {
+  await page.setViewportSize({ width: 1024, height: 900 })
+  await page.goto("/")
+  await settleWorkCards(page)
+
+  // Hold Web Animations at their first frame so the short opening motion is
+  // still inspectable after React mounts the dialog portal.
+  await page.evaluate(() => {
+    const animate = Element.prototype.animate
+    Element.prototype.animate = function (...args) {
+      const animation = animate.apply(this, args)
+      animation.pause()
+      return animation
+    }
+  })
+
+  await page.getByRole("button", { name: /Open Matcha - Multiwallet flow/ }).click()
+  await expect(page.getByRole("dialog")).toBeVisible()
+
+  const originWrap = page.locator(".preview-gallery-origin-wrap")
+  const cardInner = page.locator(".preview-gallery-card-inner")
+  expect(await originWrap.evaluate((element) => element.getAnimations().length)).toBe(1)
+  expect(await cardInner.evaluate((element) => element.getAnimations().length)).toBe(0)
+})
+
 test("keeps gallery controls inside the mobile viewport and exposes a close button", async ({ page }) => {
   await page.setViewportSize(mobileViewport)
   await page.goto("/")
@@ -1362,9 +1413,8 @@ test("keeps gallery controls inside the mobile viewport and exposes a close butt
     .locator(".preview-gallery-origin-wrap")
     .evaluate((element) => Promise.all(element.getAnimations().map((animation) => animation.finished)))
 
-  // The counter-scale has to land exactly back on identity, or the content is
-  // left a fraction of a percent off its true size.
-  await expect(page.locator(".preview-gallery-card-inner")).toHaveCSS("transform", "none")
+  // The complete surface has to land exactly back on identity.
+  await expect(page.locator(".preview-gallery-origin-wrap")).toHaveCSS("transform", "none")
 
   for (const name of ["Previous preview", "Next preview", "Close preview"]) {
     const control = dialog.getByRole("button", { name })
@@ -1796,7 +1846,9 @@ test("links each work-history company name to its primary website", async ({ pag
     { company: "0x Project", href: "https://0x.org/" },
     { company: "BoldVoice", href: "https://boldvoice.com/" },
     { company: "Moody's", href: "https://www.moodys.com/" },
-    { company: "TM (Chainlink, Twilio, and Onit)", href: "https://chain.link/" },
+    { company: "Chainlink", href: "https://chain.link/" },
+    { company: "Twilio", href: "https://www.twilio.com/" },
+    { company: "Onit", href: "https://www.onit.com/" },
     { company: "Incubeta (Google)", href: "https://www.google.com/" },
   ]
 
@@ -2096,7 +2148,7 @@ test("travels one role-bearing work-history popover between company triggers wit
   await location.evaluate((element) => Promise.all(element.getAnimations().map((animation) => animation.finished)))
   const initialLocationBox = await location.boundingBox()
   const popover = page.locator(".mosaic-work-history-popover")
-  const onit = page.getByRole("link", { name: "Onit", exact: true })
+  const onit = getPreviousCompanyLink(page, "Onit")
   const initialOnitBox = await onit.boundingBox()
 
   const closedTransform = await popover.evaluate((element) => new DOMMatrix(getComputedStyle(element).transform))
@@ -2176,7 +2228,7 @@ test("travels one role-bearing work-history popover between company triggers wit
 test("keeps a work-history pill engaged while the pointer moves into its card", async ({ page }) => {
   await page.goto("/")
 
-  const onit = page.getByRole("link", { name: "Onit", exact: true })
+  const onit = getPreviousCompanyLink(page, "Onit")
   const popover = page.locator(".mosaic-work-history-popover")
 
   await onit.hover()
@@ -2196,7 +2248,7 @@ test("opens the work-history popover from the keyboard and links each chip to it
   page,
 }) => {
   await page.goto("/")
-  const onit = page.getByRole("link", { name: "Onit", exact: true })
+  const onit = getPreviousCompanyLink(page, "Onit")
   const popover = page.locator(".mosaic-work-history-popover")
 
   await onit.focus()
@@ -2222,7 +2274,7 @@ test("opens the work-history popover from the keyboard and links each chip to it
 
 test("reveals the work-history popover for a touch pointer on a hover-capable device", async ({ page }) => {
   await page.goto("/")
-  const onit = page.getByRole("link", { name: "Onit", exact: true })
+  const onit = getPreviousCompanyLink(page, "Onit")
   const popover = page.locator(".mosaic-work-history-popover")
 
   await onit.evaluate((element) => {
@@ -2239,7 +2291,7 @@ test("reveals the work-history popover for a touch pointer on a hover-capable de
 test("keeps the work-history popover stationary while the pointer moves within a link", async ({ page }) => {
   await page.goto("/")
 
-  const trigger = page.getByRole("link", { name: "Onit", exact: true })
+  const trigger = getPreviousCompanyLink(page, "Onit")
   const popover = page.locator(".mosaic-work-history-popover")
   const triggerBox = await trigger.boundingBox()
   expect(triggerBox).not.toBeNull()
@@ -2276,7 +2328,7 @@ test("toggles the work-history popover on tap and navigates through its link", a
   const page = await context.newPage()
   await page.goto("/")
 
-  const onit = page.getByRole("link", { name: "Onit", exact: true })
+  const onit = getPreviousCompanyLink(page, "Onit")
   const popover = page.locator(".mosaic-work-history-popover")
 
   await onit.tap()
@@ -2304,7 +2356,7 @@ test("keeps the work-history popover positioned with reduced motion", async ({ p
   await page.emulateMedia({ reducedMotion: "reduce" })
   await page.goto("/")
 
-  const onit = page.getByRole("link", { name: "Onit", exact: true })
+  const onit = getPreviousCompanyLink(page, "Onit")
   const popover = page.locator(".mosaic-work-history-popover")
   await onit.focus()
   await expect(popover).toBeVisible()
@@ -2322,7 +2374,7 @@ test("keeps the work-history popover below its trigger while scrolling", async (
   await page.setViewportSize(mobileViewport)
   await page.goto("/")
 
-  const onit = page.getByRole("link", { name: "Onit", exact: true })
+  const onit = getPreviousCompanyLink(page, "Onit")
   const popover = page.locator(".mosaic-work-history-popover")
   await onit.focus()
   await expect(popover).toBeVisible()


### PR DESCRIPTION
Separates TM’s Chainlink, Twilio, and Onit resume clients into individual accessible links and darkens the Work history heading.

Stabilizes the copy-email action width, centers the X hover card on narrow screens, and updates the design-system inventory.

Simplifies the preview gallery’s origin animation so the whole surface scales together.

Adds regression coverage for these behaviors and scopes work-history selectors to avoid duplicate-link collisions.

Tests: npm run lint; npm run build; npm run test:e2e; npm run test:design-system